### PR TITLE
Make search-index write failures fatal to keep writes atomic

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -101,9 +101,15 @@ func (s *Store) createInTx(ctx context.Context, tx pgx.Tx, resourceType string, 
 		_ = br.Close()
 		return nil, fmt.Errorf("insert resource: %w", err)
 	}
-	for i := 0; i < spCount; i++ { // sp_* INSERTs (non-fatal)
+	for i := 0; i < spCount; i++ { // sp_* INSERTs
 		if _, err := br.Exec(); err != nil {
-			slog.Warn("index insert", "type", resourceType, "i", i, "err", err)
+			// Index inserts share this transaction with the resource and history
+			// writes, so a failure here must abort the whole create — otherwise the
+			// transaction is left poisoned (the history insert below would fail with
+			// a misleading error) and a resource could be persisted with an
+			// incomplete search index.
+			_ = br.Close()
+			return nil, fmt.Errorf("insert index entry %d (%s/%s): %w", i, resourceType, resourceID, err)
 		}
 	}
 	if _, err := br.Exec(); err != nil { // history INSERT
@@ -213,9 +219,13 @@ func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 		}
 	}
 	spInsertCount := spInsertEnd - 1 - nDeletes // 1 UPDATE + nDeletes DELETEs precede the sp_* INSERTs
-	for i := 0; i < spInsertCount; i++ {        // sp_* INSERTs (non-fatal)
+	for i := 0; i < spInsertCount; i++ {        // sp_* INSERTs
 		if _, err := br.Exec(); err != nil {
-			slog.Warn("index insert", "type", resourceType, "i", i, "err", err)
+			// Fatal for the same reason as in createInTx: a failed index insert
+			// poisons this transaction, so the update must roll back atomically
+			// rather than persist a resource with a stale/incomplete index.
+			_ = br.Close()
+			return nil, fmt.Errorf("insert index entry %d (%s/%s): %w", i, resourceType, resourceID, err)
 		}
 	}
 	if _, err := br.Exec(); err != nil { // history INSERT
@@ -315,9 +325,13 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 		}
 	}
 	spInsertCount := spInsertEnd - 1 - nDeletes
-	for i := 0; i < spInsertCount; i++ { // sp_* INSERTs (non-fatal)
+	for i := 0; i < spInsertCount; i++ { // sp_* INSERTs
 		if _, err := br.Exec(); err != nil {
-			slog.Warn("index insert", "type", resourceType, "i", i, "err", err)
+			// Fatal for the same reason as in createInTx: a failed index insert
+			// poisons this transaction, so the patch must roll back atomically
+			// rather than persist a resource with a stale/incomplete index.
+			_ = br.Close()
+			return nil, 0, fmt.Errorf("insert index entry %d (%s/%s): %w", i, resourceType, resourceID, err)
 		}
 	}
 	if _, err := br.Exec(); err != nil { // history INSERT


### PR DESCRIPTION
## Summary

The `sp_*` search-index INSERTs share a single transaction with the resource and history writes in `createInTx` / `updateInTx` / `patchInTx`. Previously a failed index INSERT was only logged at `Warn` and execution continued.

Because the failed statement poisons the Postgres transaction, the next statement — the history INSERT — then failed with a misleading `insert history` error, while the real cause sat at `Warn`. So the intended "non-fatal index" behaviour was never actually achieved: an index failure already failed the whole write (and, inside a transaction Bundle, the whole bundle), just with the wrong error surfaced.

## Change

Treat index INSERT errors as **fatal**, matching the existing index **DELETE** handling immediately above each loop: abort the transaction and return the real cause (`insert index entry N (Type/id): <cause>`). Writes are now genuinely atomic — resource, index, and history all commit, or none do.

Applied consistently to all three write paths: create, update (PUT), and patch (PATCH).

## Why not async retry

The failures that reach *only* the `sp_*` inserts are deterministic data/constraint errors (e.g. a value that violates a column type), not transient ones — transient failures already roll back the entire transaction cleanly. Retrying deterministic failures buys nothing. If non-blocking indexing is ever required, the right design is a durable reindex outbox + worker, not in-memory retry; that's out of scope here.

## Testing

- `gofmt` clean, `go vet ./internal/store/` clean, `go build ./...` passes
- `go test ./internal/store/ ./internal/handler/` passes

The failure path is only reachable with a real database and an injected constraint violation, so it isn't unit-testable without brittle injection; not adding an integration test for it here.