### PR TITLE
feat: multi-tenancy (logical tenant-in-URL + physical)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ A FHIR R4 REST server written in Go, backed by PostgreSQL. It replaces a legacy 
 2. [Running Without Docker](#2-running-without-docker)
 3. [Configuration Reference](#3-configuration-reference)
 4. [Architecture](#4-architecture)
-5. [Database Schema](#5-database-schema)
-6. [API Reference](#6-api-reference)
-7. [Search Parameters](#7-search-parameters)
-8. [Terminology](#8-terminology)
-9. [Implementation Guides](#9-implementation-guides)
-10. [Testing](#10-testing)
-11. [Extending the Server](#11-extending-the-server)
+5. [Multi-Tenancy](#5-multi-tenancy)
+6. [Database Schema](#6-database-schema)
+7. [API Reference](#7-api-reference)
+8. [Search Parameters](#8-search-parameters)
+9. [Terminology](#9-terminology)
+10. [Implementation Guides](#10-implementation-guides)
+11. [Testing](#11-testing)
+12. [Extending the Server](#12-extending-the-server)
 
 ---
 
@@ -163,7 +164,7 @@ ig:
 | YAML key | Env var | Default | Description |
 |---|---|---|---|
 | `server.port` | `SERVER_PORT` | `9090` | HTTP listen port |
-| `server.baseUrl` | `BASE_URL` | `http://localhost:{port}/fhir/r4` | Canonical server base URL. Written into bundle `link` URLs and the CapabilityStatement. Must match the address clients use. |
+| `server.baseUrl` | `BASE_URL` | `http://localhost:{port}/fhir/r4` | Canonical server base URL. Written into bundle `link` URLs and the CapabilityStatement. Must match the address clients use. For multi-tenant requests the `/t/{tenant}` prefix is inserted automatically (see [Multi-Tenancy](#5-multi-tenancy)), so set this to the bare base path. |
 | `logging.level` | `LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error`. Logs are JSON (structured). |
 | `database.url` | `DATABASE_URL` | *(derived)* | Full PostgreSQL DSN. When set, overrides every other `database.*` field. |
 | `database.host` | `DB_HOST` | `localhost` | PostgreSQL host (only used when `database.url` is empty) |
@@ -171,11 +172,11 @@ ig:
 | `database.user` | `DB_USER` | `fhir` | PostgreSQL user |
 | `database.password` | `DB_PASSWORD` | `fhir` | PostgreSQL password |
 | `database.name` | `DB_NAME` | `fhirdb` | PostgreSQL database name |
-| `ig.packages` | `IG_PACKAGES` | *(empty)* | List of IG package specs to load at startup. In env vars, comma-separated. See [Implementation Guides](#9-implementation-guides). |
+| `ig.packages` | `IG_PACKAGES` | *(empty)* | List of IG package specs to load at startup. In env vars, comma-separated. See [Implementation Guides](#10-implementation-guides). |
 | `ig.registryUrl` | `IG_REGISTRY_URL` | `https://packages.fhir.org` | FHIR package registry for resolving `name@version` specs. |
 | `ig.forceReload` | `IG_FORCE_RELOAD` | `false` | Set to `true` to re-download and re-process IGs even if already recorded in the database. |
 | `ig.cacheDir` | `IG_CACHE_DIR` | `.fhir-ig-cache` | Directory for caching downloaded `.tgz` packages between restarts. |
-| *(env only)* | `FHIR_TERMINOLOGY_URL` | *(empty)* | Base URL of an external FHIR terminology server used for ValueSet `$expand` (e.g. `https://tx.fhir.org/r4`). Empty disables the `:in` / `:not-in` / `:below` / `:above` search filters. See [Terminology](#8-terminology). |
+| *(env only)* | `FHIR_TERMINOLOGY_URL` | *(empty)* | Base URL of an external FHIR terminology server used for ValueSet `$expand` (e.g. `https://tx.fhir.org/r4`). Empty disables the `:in` / `:not-in` / `:below` / `:above` search filters. See [Terminology](#9-terminology). |
 
 > **Secrets:** Prefer environment variables (or a secret-manager-backed env) for `DB_PASSWORD` and any other sensitive value rather than committing them to the YAML file.
 
@@ -269,9 +270,64 @@ If `IG_PACKAGES` is empty, steps 8–9 are skipped and the server is ready immed
 
 ---
 
-## 5. Database Schema
+## 5. Multi-Tenancy
 
-Migrations run automatically at startup via `db.Migrate()`. The SQL is embedded in the binary (`internal/db/schema.sql`, schema version 3). All statements are idempotent (`CREATE TABLE IF NOT EXISTS`, `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`), so re-running against an existing database is safe.
+The server supports two ways to serve multiple tenants from one deployment. They can be used independently or together (a gateway can route some tenants to dedicated instances and the rest to a shared one).
+
+### Option 1 — Physical separation (a dedicated server **and** database per tenant)
+
+Give each tenant its own full deployment — a server instance **and** its own database — and put a gateway in front that routes each tenant to its backend:
+
+```text
+                          ┌────────────────┐   ┌─────────────┐
+   /t/acme/...    ─────▶  │ fhir-server    │──▶│ acme  DB    │
+                          └────────────────┘   └─────────────┘
+                          ┌────────────────┐   ┌─────────────┐
+   /t/globex/...  ─────▶  │ fhir-server    │──▶│ globex DB   │
+                          └────────────────┘   └─────────────┘
+```
+
+This needs **no application configuration** — each instance is a normal single-tenant server pointed at its own `DATABASE_URL`. It gives the strongest isolation (separate data, backups, and blast radius) and is the recommended model for a small number of larger tenants or strict compliance/data-residency requirements. The trade-off is operational overhead that grows with the number of tenants.
+
+> A **single server fronting one database per tenant** (a connection pool per tenant inside one process) is intentionally **not** supported: each tenant's pool consumes connections, so one process can only serve a small, fixed number of tenants before exhausting them. For many tenants on shared infrastructure, use Option 2 instead.
+
+### Option 2 — Logical separation (shared server and database)
+
+All tenants share one server and one database; every row is tagged with a `tenant_id` and isolation is enforced by PostgreSQL **Row-Level Security**. The active tenant is taken from the **URL**:
+
+```text
+POST /t/{tenant}/fhir/r4/Patient        # tenant "{tenant}"
+GET  /t/acme/fhir/r4/Patient?name=smith # tenant "acme"
+GET  /fhir/r4/Patient/123               # the "default" tenant (no prefix)
+```
+
+- **Tenant in the URL.** Requests under `/t/{tenant}/…` act on that tenant; requests on the bare `/fhir/r4/…` base act on the `default` tenant, so **existing single-tenant deployments keep working unchanged**. Each tenant therefore has its own FHIR base URL (`…/t/{tenant}/fhir/r4`), and generated absolute URLs (`Location`, Bundle `fullUrl`, pagination links) carry the prefix so clients stay within their tenant.
+- **Enforced by the database, not just the query.** On every request the server sets the `app.current_tenant` Postgres setting (via `SET LOCAL` inside write transactions; per-connection for reads). RLS policies on `resources`, `resource_history`, and the `sp_*` index tables restrict every read and write to the matching `tenant_id`. A query that forgets to filter — or a bug in the application layer — still cannot cross tenants. New rows derive their `tenant_id` from the same setting, and an unset tenant fails closed.
+- **Tenant identifiers** must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`; anything else is rejected with `404`.
+
+> **⚠️ The database role must NOT be a superuser.** PostgreSQL superusers — and any role with `BYPASSRLS` — ignore Row-Level Security, which would silently disable tenant isolation. Create a dedicated least-privilege role for the server and connect as it:
+>
+> ```sql
+> CREATE ROLE fhir_app LOGIN PASSWORD '…';            -- NOT a superuser
+> GRANT USAGE ON SCHEMA public TO fhir_app;
+> GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO fhir_app;
+> GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO fhir_app;
+> ```
+>
+> (Run migrations as the owner/admin role; run the server as `fhir_app`.) Single-tenant deployments that never use the tenant routes are unaffected either way.
+>
+> **Security:** the server trusts the tenant in the URL — it performs no authentication of its own. Deploy it behind a gateway or auth proxy (e.g. WSO2 API Manager) that authenticates the caller and authorizes them for the `{tenant}` they address. Do not expose the tenant routes directly to untrusted clients.
+
+**What is shared vs. isolated.** PHI lives in tenant-scoped tables (`resources`, `resource_history`, `sp_*`) and is isolated per tenant. Server-wide *configuration* is intentionally shared across tenants: the search-parameter registry (including custom `SearchParameter`s) and loaded Implementation Guides. If you need per-tenant search parameters or IGs, use Option 1.
+
+The `resources`, `resource_history`, and `sp_*` indexes lead with `tenant_id`, so tenant-scoped reads and writes stay selective as the number of tenants grows. For a single-tenant (`default`) deployment the leading column is constant and effectively free.
+
+---
+
+
+## 6. Database Schema
+
+The schema is embedded in the binary (`internal/db/schema.sql`, schema version 6) and applied at startup via `db.Migrate()`. It describes the database from scratch — every PHI table carries a `tenant_id` column and tenant-leading primary/foreign keys, and Row-Level Security is declared on each (see [Multi-Tenancy](#5-multi-tenancy)). Statements use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` so a fresh database can be (re)initialised safely. Upgrading a pre-existing database to a new schema version is handled by a separate migration step.
 
 ### Core tables
 
@@ -279,6 +335,7 @@ Migrations run automatically at startup via `db.Migrate()`. The SQL is embedded 
 
 | Column | Type | Notes |
 |---|---|---|
+| `tenant_id` | `TEXT` | Owning tenant; defaults to `current_setting('app.current_tenant')` (see [Multi-Tenancy](#5-multi-tenancy)) |
 | `fhir_id` | `VARCHAR(64)` | FHIR logical id (UUID or server-assigned) |
 | `resource_type` | `VARCHAR(100)` | e.g. `Patient`, `Observation` |
 | `version_id` | `INT` | Monotonically increasing per resource |
@@ -287,7 +344,7 @@ Migrations run automatically at startup via `db.Migrate()`. The SQL is embedded 
 | `resource_json` | `JSONB` | Full resource body |
 | `search_text` | `TSVECTOR` | Reserved for `_text`/`_content` full-text search — column exists but is not currently populated by the server |
 
-Primary key: `(fhir_id, resource_type)`.
+Primary key: `(tenant_id, resource_type, fhir_id)`.
 
 #### `resource_history` — append-only audit trail
 
@@ -295,12 +352,15 @@ Every create, update, and delete appends a row here. VRead (`GET /{type}/{id}/_h
 
 | Column | Type | Notes |
 |---|---|---|
+| `tenant_id` | `TEXT` | Owning tenant (see [Multi-Tenancy](#5-multi-tenancy)) |
 | `fhir_id` | `VARCHAR(64)` | |
 | `resource_type` | `VARCHAR(100)` | |
 | `version_id` | `INT` | |
 | `operation` | `VARCHAR(10)` | `POST` (create), `PUT` (update), or `DELETE` |
 | `recorded_at` | `TIMESTAMPTZ` | |
 | `resource_json` | `JSONB` | Full snapshot at this version |
+
+Unique key: `(tenant_id, fhir_id, resource_type, version_id)`.
 
 #### `sp_*` — search index tables
 
@@ -317,7 +377,7 @@ One table per FHIR search parameter type. Rows are deleted and re-inserted on ev
 | `sp_reference` | `reference` | `target_type`, `target_id` + identifier columns for `:identifier` modifier |
 | `sp_coords` | `special` | `latitude`, `longitude` (Location.near) |
 
-All `sp_*` tables have `FOREIGN KEY (resource_id, resource_type) REFERENCES resources ON DELETE CASCADE`.
+All `sp_*` tables carry a `tenant_id` column and have `FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources ON DELETE CASCADE`. Their indexes also lead with `tenant_id`.
 
 #### `search_param_definitions` — search parameter registry
 
@@ -336,7 +396,7 @@ Track which IG packages have been loaded (for skip-on-restart) and which profile
 
 ---
 
-## 6. API Reference
+## 7. API Reference
 
 **Base path:** `/fhir/r4`  
 **Content-Type:** All request and response bodies use `application/fhir+json`.  
@@ -622,7 +682,7 @@ These checks apply to both `POST /{type}` (create), `PUT /{type}/{id}` (update),
 
 ---
 
-## 7. Search Parameters
+## 8. Search Parameters
 
 ### Built-in parameters
 
@@ -633,7 +693,7 @@ These checks apply to both `POST /{type}` (create), `PUT /{type}/{id}` (update),
 | Type | Example | Modifiers | Notes |
 |---|---|---|---|
 | `string` | `family=smith` | `:exact`, `:contains`, `:missing` | Default is case-insensitive prefix match |
-| `token` | `gender=female`, `code=http://loinc.org\|8310-5` | `:missing`, `:in`, `:not-in`, `:below`, `:above` | `system\|code`, `\|code` (any system), `system\|` (any code with that system). The `:in`/`:not-in`/`:below`/`:above` modifiers require an external terminology server — see [Terminology](#8-terminology). |
+| `token` | `gender=female`, `code=http://loinc.org\|8310-5` | `:missing`, `:in`, `:not-in`, `:below`, `:above` | `system\|code`, `\|code` (any system), `system\|` (any code with that system). The `:in`/`:not-in`/`:below`/`:above` modifiers require an external terminology server — see [Terminology](#9-terminology). |
 | `date` | `birthdate=ge1980`, `date=2024-01-15` | `eq`, `ne`, `lt`, `gt`, `le`, `ge` | `sa`/`eb` parse but fall back to `eq` |
 | `number` | `probability=gt0.8` | `eq`, `lt`, `gt` | |
 | `reference` | `subject=Patient/abc123` | — | |
@@ -678,7 +738,7 @@ The parameter is available for searching immediately and persists across restart
 
 ---
 
-## 8. Terminology
+## 9. Terminology
 
 The server is **not a terminology server**. It does not host `CodeSystem`, `ValueSet`, or `ConceptMap` resources, it does not expose terminology operations (`$validate-code`, `$lookup`, `$translate`), and resource validation does **not** check coded values against their bound value sets (see [Validation rules](#validation-rules) — validation is structural only: cardinality, fixed values, patterns, FHIRPath invariants, and slicing).
 
@@ -718,7 +778,7 @@ If you need full terminology capabilities — hosting your own code systems and 
 
 ---
 
-## 9. Implementation Guides
+## 10. Implementation Guides
 
 IGs extend the server with additional SearchParameters and profiles without code changes.
 
@@ -758,7 +818,7 @@ curl http://localhost:9090/fhir/r4/metadata | jq '.implementationGuide'
 
 ---
 
-## 10. Testing
+## 11. Testing
 
 See [TESTING.md](TESTING.md) for the full test inventory. Quick reference:
 
@@ -800,7 +860,7 @@ go test -tags integration ./...
 
 ---
 
-## 11. Extending the Server
+## 12. Extending the Server
 
 ### Adding a required-field validation rule
 

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 -- benefit to the query patterns used here.
 
 CREATE TABLE IF NOT EXISTS resources (
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     fhir_id       VARCHAR(64)  NOT NULL,
     resource_type VARCHAR(100) NOT NULL,
     version_id    INT          NOT NULL DEFAULT 1,
@@ -26,13 +27,13 @@ CREATE TABLE IF NOT EXISTS resources (
     is_deleted    BOOLEAN      NOT NULL DEFAULT FALSE,
     resource_json JSONB        NOT NULL,
     search_text   TSVECTOR,
-    PRIMARY KEY (fhir_id, resource_type)
+    PRIMARY KEY (tenant_id, resource_type, fhir_id)
 );
 
 -- List all resources of a type ordered by recency (used by GET /{type}).
-CREATE INDEX IF NOT EXISTS idx_res_type_updated ON resources (resource_type, last_updated DESC);
+CREATE INDEX IF NOT EXISTS idx_res_type_updated ON resources (tenant_id, resource_type, last_updated DESC);
 -- Same as above but skips soft-deleted resources (used by most searches).
-CREATE INDEX IF NOT EXISTS idx_res_active       ON resources (resource_type, last_updated DESC) WHERE is_deleted = FALSE;
+CREATE INDEX IF NOT EXISTS idx_res_active       ON resources (tenant_id, resource_type, last_updated DESC) WHERE is_deleted = FALSE;
 -- Full-text search over search_text (_text / _content search parameters).
 CREATE INDEX IF NOT EXISTS idx_res_search_text  ON resources USING GIN (search_text);
 
@@ -42,21 +43,22 @@ CREATE INDEX IF NOT EXISTS idx_res_search_text  ON resources USING GIN (search_t
 
 CREATE TABLE IF NOT EXISTS resource_history (
     id            BIGSERIAL    PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     fhir_id       VARCHAR(64)  NOT NULL,
     resource_type VARCHAR(100) NOT NULL,
     version_id    INT          NOT NULL,
     operation     VARCHAR(10)  NOT NULL,   -- CREATE | UPDATE | DELETE
     recorded_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     resource_json JSONB,
-    UNIQUE (fhir_id, resource_type, version_id)
+    UNIQUE (tenant_id, fhir_id, resource_type, version_id)
 );
 
 -- Fetch a specific version of a resource (GET /{type}/{id}/_history/{vid}).
-CREATE INDEX IF NOT EXISTS idx_hist_resource  ON resource_history (resource_type, fhir_id, version_id DESC);
+CREATE INDEX IF NOT EXISTS idx_hist_resource  ON resource_history (tenant_id, resource_type, fhir_id, version_id DESC);
 -- Global history feed ordered by time (GET /_history).
-CREATE INDEX IF NOT EXISTS idx_hist_time      ON resource_history (recorded_at DESC);
+CREATE INDEX IF NOT EXISTS idx_hist_time      ON resource_history (tenant_id, recorded_at DESC);
 -- History feed for a single resource type ordered by time (GET /{type}/_history).
-CREATE INDEX IF NOT EXISTS idx_hist_type_time ON resource_history (resource_type, recorded_at DESC);
+CREATE INDEX IF NOT EXISTS idx_hist_type_time ON resource_history (tenant_id, resource_type, recorded_at DESC);
 
 -- ─── String search index ─────────────────────────────────────────────────────
 -- Stores extracted values for FHIR string search parameters (name, address, etc.).
@@ -65,24 +67,25 @@ CREATE INDEX IF NOT EXISTS idx_hist_type_time ON resource_history (resource_type
 
 CREATE TABLE IF NOT EXISTS sp_string (
     id            BIGSERIAL    PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id   VARCHAR(64)  NOT NULL,
     resource_type VARCHAR(100) NOT NULL,
     param_name    VARCHAR(191) NOT NULL,
     value_exact   VARCHAR(512),
     value_lower   VARCHAR(512),
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
 -- text_pattern_ops is required for LIKE 'prefix%' to use a btree index under
 -- non-C collations (e.g. en_US.utf8). Without it, prefix scans fall back to
 -- a sequential scan. The operator class also serves equality lookups.
-CREATE INDEX IF NOT EXISTS idx_sp_str_lower_pattern ON sp_string (resource_type, param_name, value_lower text_pattern_ops);
-CREATE INDEX IF NOT EXISTS idx_sp_str_exact         ON sp_string (resource_type, param_name, value_exact);
+CREATE INDEX IF NOT EXISTS idx_sp_str_lower_pattern ON sp_string (tenant_id, resource_type, param_name, value_lower text_pattern_ops);
+CREATE INDEX IF NOT EXISTS idx_sp_str_exact         ON sp_string (tenant_id, resource_type, param_name, value_exact);
 -- Narrow re-index/cascade index. Serves per-resource re-index DELETEs
 -- (WHERE resource_id, resource_type) and FK ON DELETE CASCADE. Slimmed from the
 -- former wide form (…param_name, value_lower) to cut ingest write amplification;
 -- the wide form's only extra benefit was index-only multi-param search joins.
-CREATE INDEX IF NOT EXISTS idx_sp_str_source        ON sp_string (resource_id, resource_type);
+CREATE INDEX IF NOT EXISTS idx_sp_str_source        ON sp_string (tenant_id, resource_id, resource_type);
 -- Uncomment for :contains support (requires pg_trgm extension):
 -- CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- CREATE INDEX idx_sp_str_trgm ON sp_string USING GIN (value_lower gin_trgm_ops);
@@ -94,24 +97,25 @@ CREATE INDEX IF NOT EXISTS idx_sp_str_source        ON sp_string (resource_id, r
 
 CREATE TABLE IF NOT EXISTS sp_token (
     id            BIGSERIAL    PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id   VARCHAR(64)  NOT NULL,
     resource_type VARCHAR(100) NOT NULL,
     param_name    VARCHAR(191) NOT NULL,
     system        VARCHAR(512),
     code          VARCHAR(191),
     display       VARCHAR(512),
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
 -- Primary lookup: system|code pairs (the most common token search pattern).
-CREATE INDEX IF NOT EXISTS idx_sp_tok_sys_code ON sp_token (resource_type, param_name, system, code);
+CREATE INDEX IF NOT EXISTS idx_sp_tok_sys_code ON sp_token (tenant_id, resource_type, param_name, system, code);
 -- (idx_sp_tok_system dropped: it was a strict prefix of idx_sp_tok_sys_code
 --  above, which the planner already uses for system-only lookups — the separate
 --  index only added write cost on the heaviest sp_* table.)
 -- Lookup by code alone when the search omits system.
-CREATE INDEX IF NOT EXISTS idx_sp_tok_code ON sp_token (resource_type, param_name, code) WHERE code IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sp_tok_code ON sp_token (tenant_id, resource_type, param_name, code) WHERE code IS NOT NULL;
 -- Narrow re-index/cascade index (slimmed from …param_name, system, code).
-CREATE INDEX IF NOT EXISTS idx_sp_tok_source ON sp_token (resource_id, resource_type);
+CREATE INDEX IF NOT EXISTS idx_sp_tok_source ON sp_token (tenant_id, resource_id, resource_type);
 
 -- ─── Date search index ────────────────────────────────────────────────────────
 -- Stores extracted values for FHIR date / dateTime / Period / instant parameters.
@@ -122,18 +126,19 @@ CREATE INDEX IF NOT EXISTS idx_sp_tok_source ON sp_token (resource_id, resource_
 
 CREATE TABLE IF NOT EXISTS sp_date (
     id              BIGSERIAL    PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id     VARCHAR(64)  NOT NULL,
     resource_type   VARCHAR(100) NOT NULL,
     param_name      VARCHAR(191) NOT NULL,
     value_low       TIMESTAMPTZ  NOT NULL,
     value_high      TIMESTAMPTZ  NOT NULL,
     value_precision VARCHAR(10)  NOT NULL DEFAULT 'SECOND',
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_sp_date_range  ON sp_date (resource_type, param_name, value_low, value_high);
+CREATE INDEX IF NOT EXISTS idx_sp_date_range  ON sp_date (tenant_id, resource_type, param_name, value_low, value_high);
 -- Narrow re-index/cascade index (slimmed from …param_name, value_low, value_high).
-CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (resource_id, resource_type);
+CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (tenant_id, resource_id, resource_type);
 
 -- ─── Number search index ──────────────────────────────────────────────────────
 -- Stores extracted values for FHIR number search parameters.
@@ -143,18 +148,19 @@ CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (resource_id, resource_
 
 CREATE TABLE IF NOT EXISTS sp_number (
     id            BIGSERIAL     PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id   VARCHAR(64)   NOT NULL,
     resource_type VARCHAR(100)  NOT NULL,
     param_name    VARCHAR(191)  NOT NULL,
     value         DECIMAL(20,6) NOT NULL,
     value_low     DECIMAL(20,6) NOT NULL,
     value_high    DECIMAL(20,6) NOT NULL,
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_sp_num_range  ON sp_number (resource_type, param_name, value_low, value_high);
+CREATE INDEX IF NOT EXISTS idx_sp_num_range  ON sp_number (tenant_id, resource_type, param_name, value_low, value_high);
 -- Narrow re-index/cascade index (slimmed from …param_name, value_low, value_high).
-CREATE INDEX IF NOT EXISTS idx_sp_num_source ON sp_number (resource_id, resource_type);
+CREATE INDEX IF NOT EXISTS idx_sp_num_source ON sp_number (tenant_id, resource_id, resource_type);
 
 -- ─── Quantity search index ────────────────────────────────────────────────────
 -- Stores extracted values for FHIR quantity search parameters.
@@ -164,6 +170,7 @@ CREATE INDEX IF NOT EXISTS idx_sp_num_source ON sp_number (resource_id, resource
 
 CREATE TABLE IF NOT EXISTS sp_quantity (
     id               BIGSERIAL     PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id      VARCHAR(64)   NOT NULL,
     resource_type    VARCHAR(100)  NOT NULL,
     param_name       VARCHAR(191)  NOT NULL,
@@ -174,15 +181,15 @@ CREATE TABLE IF NOT EXISTS sp_quantity (
     code             VARCHAR(64),
     canonical_value  DECIMAL(20,6),
     canonical_units  VARCHAR(64),
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
 -- Raw value range search (same system+code, no unit conversion needed).
-CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (resource_type, param_name, value_low, value_high, system, code);
+CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (tenant_id, resource_type, param_name, value_low, value_high, system, code);
 -- Narrow re-index/cascade index (slimmed from …param_name).
-CREATE INDEX IF NOT EXISTS idx_sp_qty_source    ON sp_quantity (resource_id, resource_type);
+CREATE INDEX IF NOT EXISTS idx_sp_qty_source    ON sp_quantity (tenant_id, resource_id, resource_type);
 -- Canonical search (cross-unit comparison via UCUM normalisation).
-CREATE INDEX IF NOT EXISTS idx_sp_qty_canonical ON sp_quantity (resource_type, param_name, canonical_value, canonical_units)
+CREATE INDEX IF NOT EXISTS idx_sp_qty_canonical ON sp_quantity (tenant_id, resource_type, param_name, canonical_value, canonical_units)
     WHERE canonical_value IS NOT NULL;
 
 -- ─── URI search index ─────────────────────────────────────────────────────────
@@ -191,18 +198,19 @@ CREATE INDEX IF NOT EXISTS idx_sp_qty_canonical ON sp_quantity (resource_type, p
 
 CREATE TABLE IF NOT EXISTS sp_uri (
     id            BIGSERIAL    PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id   VARCHAR(64)  NOT NULL,
     resource_type VARCHAR(100) NOT NULL,
     param_name    VARCHAR(191) NOT NULL,
     value         VARCHAR(512) NOT NULL,
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_sp_uri_exact  ON sp_uri (resource_type, param_name, value);
+CREATE INDEX IF NOT EXISTS idx_sp_uri_exact  ON sp_uri (tenant_id, resource_type, param_name, value);
 -- text_pattern_ops enables efficient LIKE 'prefix%' for the :below modifier.
-CREATE INDEX IF NOT EXISTS idx_sp_uri_prefix ON sp_uri (resource_type, param_name, value text_pattern_ops);
+CREATE INDEX IF NOT EXISTS idx_sp_uri_prefix ON sp_uri (tenant_id, resource_type, param_name, value text_pattern_ops);
 -- Narrow re-index/cascade index (slimmed from …param_name, value).
-CREATE INDEX IF NOT EXISTS idx_sp_uri_source ON sp_uri (resource_id, resource_type);
+CREATE INDEX IF NOT EXISTS idx_sp_uri_source ON sp_uri (tenant_id, resource_id, resource_type);
 
 -- ─── Reference search index ───────────────────────────────────────────────────
 -- Stores extracted values for FHIR reference search parameters.
@@ -213,6 +221,7 @@ CREATE INDEX IF NOT EXISTS idx_sp_uri_source ON sp_uri (resource_id, resource_ty
 
 CREATE TABLE IF NOT EXISTS sp_reference (
     id                BIGSERIAL    PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id       VARCHAR(64)  NOT NULL,
     resource_type     VARCHAR(100) NOT NULL,
     param_name        VARCHAR(191) NOT NULL,
@@ -223,16 +232,16 @@ CREATE TABLE IF NOT EXISTS sp_reference (
     identifier_system VARCHAR(512),
     identifier_value  VARCHAR(255),
     display           VARCHAR(255),
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
 -- Narrow re-index/cascade index (slimmed from …param_name, target_id).
-CREATE INDEX IF NOT EXISTS idx_sp_ref_source      ON sp_reference (resource_id, resource_type);
+CREATE INDEX IF NOT EXISTS idx_sp_ref_source      ON sp_reference (tenant_id, resource_id, resource_type);
 -- Used when searching by target (e.g. ?patient=123): leading on target_id
 -- serves bare-id lookups; extra columns allow the predicate to resolve index-only.
-CREATE INDEX IF NOT EXISTS idx_sp_ref_target_full ON sp_reference (target_id, target_type, param_name, resource_type, resource_id);
+CREATE INDEX IF NOT EXISTS idx_sp_ref_target_full ON sp_reference (tenant_id, target_id, target_type, param_name, resource_type, resource_id);
 -- Used for the :identifier modifier (find references by Identifier value).
-CREATE INDEX IF NOT EXISTS idx_sp_ref_ident       ON sp_reference (target_type, identifier_system, identifier_value)
+CREATE INDEX IF NOT EXISTS idx_sp_ref_ident       ON sp_reference (tenant_id, target_type, identifier_system, identifier_value)
     WHERE identifier_value IS NOT NULL;
 
 -- ─── Coordinates search index ─────────────────────────────────────────────────
@@ -242,15 +251,16 @@ CREATE INDEX IF NOT EXISTS idx_sp_ref_ident       ON sp_reference (target_type, 
 
 CREATE TABLE IF NOT EXISTS sp_coords (
     id            BIGSERIAL    PRIMARY KEY,
+    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id   VARCHAR(64)  NOT NULL,
     resource_type VARCHAR(100) NOT NULL,
     param_name    VARCHAR(191) NOT NULL,
     latitude      DECIMAL(9,6) NOT NULL,
     longitude     DECIMAL(9,6) NOT NULL,
-    FOREIGN KEY (resource_id, resource_type) REFERENCES resources (fhir_id, resource_type) ON DELETE CASCADE
+    FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_sp_coords ON sp_coords (resource_type, param_name, latitude, longitude);
+CREATE INDEX IF NOT EXISTS idx_sp_coords ON sp_coords (tenant_id, resource_type, param_name, latitude, longitude);
 
 -- ─── Search parameter definitions ────────────────────────────────────────────
 -- Registry of all known search parameters for each resource type.
@@ -383,3 +393,43 @@ ALTER TABLE sp_coords    SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_
 -- installs get the lean form; existing DBs need a migration to DROP+recreate
 -- (CREATE INDEX IF NOT EXISTS won't alter an index that already exists).
 INSERT INTO schema_version (version) VALUES (5) ON CONFLICT DO NOTHING;
+
+-- ─── Multi-tenancy: Row-Level Security ────────────────────────────────────────
+-- Every PHI-bearing table (resources, resource_history, sp_*) carries a
+-- tenant_id column (declared inline in the definitions above) that defaults to
+-- the app.current_tenant runtime setting the server applies per request. Their
+-- primary / foreign keys and the resource_history version-uniqueness all lead
+-- with tenant_id, so two tenants may hold resources with the same id. The
+-- global configuration tables (search_param_definitions, ig_*, the closure
+-- tables, schema_version) are intentionally SHARED across tenants and carry no
+-- tenant_id.
+--
+-- Isolation is enforced by Row-Level Security: each policy restricts rows to
+-- the current tenant. FORCE makes the policy apply to the table owner too. An
+-- unset tenant fails CLOSED — NULL matches no rows and violates the NOT NULL
+-- tenant_id on write.
+--
+-- NOTE: the server (and any tooling that touches these tables at runtime) MUST
+-- connect as a NON-superuser role — superusers and roles with BYPASSRLS ignore
+-- Row-Level Security entirely.
+DO $rls$
+DECLARE
+    t             text;
+    tenant_tables text[] := ARRAY['resources','resource_history','sp_string','sp_token',
+                                  'sp_date','sp_number','sp_quantity','sp_uri',
+                                  'sp_reference','sp_coords'];
+BEGIN
+    FOREACH t IN ARRAY tenant_tables LOOP
+        EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+        EXECUTE format('ALTER TABLE %I FORCE  ROW LEVEL SECURITY', t);
+        EXECUTE format('DROP POLICY IF EXISTS tenant_isolation ON %I', t);
+        EXECUTE format(
+            'CREATE POLICY tenant_isolation ON %I '
+            || 'USING (tenant_id = current_setting(''app.current_tenant'', true)) '
+            || 'WITH CHECK (tenant_id = current_setting(''app.current_tenant'', true))',
+            t);
+    END LOOP;
+END
+$rls$;
+
+INSERT INTO schema_version (version) VALUES (6) ON CONFLICT DO NOTHING;

--- a/internal/handler/bundle.go
+++ b/internal/handler/bundle.go
@@ -57,7 +57,7 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := h.store.ExecuteBundle(r.Context(), bundleType, h.baseURL, entries)
+	results, err := h.store.ExecuteBundle(r.Context(), bundleType, h.tenantBaseURL(r.Context()), entries)
 	if err != nil {
 		var be *store.BundleError
 		if errors.As(err, &be) {
@@ -108,16 +108,16 @@ func (h *fhirHandler) bundle(w http.ResponseWriter, r *http.Request) {
 	if bundleType == "batch" {
 		responseType = "batch-response"
 	}
-	writeJSON(w, http.StatusOK, h.buildBundleResponse(responseType, results))
+	writeJSON(w, http.StatusOK, h.buildBundleResponse(h.tenantBaseURL(r.Context()), responseType, results))
 }
 
 // buildBundleResponse assembles the transaction-response / batch-response Bundle.
-func (h *fhirHandler) buildBundleResponse(responseType string, results []store.BundleEntryResult) map[string]any {
+func (h *fhirHandler) buildBundleResponse(base, responseType string, results []store.BundleEntryResult) map[string]any {
 	entries := make([]any, 0, len(results))
 	for _, res := range results {
 		response := map[string]any{"status": res.Status}
 		if res.Location != "" {
-			response["location"] = h.absoluteLocation(res.Location)
+			response["location"] = h.absoluteLocation(base, res.Location)
 		}
 		if res.ETag != "" {
 			response["etag"] = res.ETag
@@ -142,11 +142,11 @@ func (h *fhirHandler) buildBundleResponse(responseType string, results []store.B
 
 // absoluteLocation turns a relative "Type/id/_history/v" location into an
 // absolute URL under the server base.
-func (h *fhirHandler) absoluteLocation(loc string) string {
+func (h *fhirHandler) absoluteLocation(base, loc string) string {
 	if strings.Contains(loc, "://") {
 		return loc
 	}
-	return strings.TrimRight(h.baseURL, "/") + "/" + strings.TrimLeft(loc, "/")
+	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(loc, "/")
 }
 
 // parseBundleEntries converts the raw Bundle.entry array into typed store

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -281,7 +281,7 @@ func (h *fhirHandler) search(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bundle := h.buildBundle(rt, result, params, page, pageSize, summary, elements)
+	bundle := h.buildBundle(h.tenantBaseURL(r.Context()), rt, result, params, page, pageSize, summary, elements)
 	writeFHIR(w, r, http.StatusOK, bundle)
 }
 
@@ -325,11 +325,11 @@ func (h *fhirHandler) searchPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bundle := h.buildBundle(rt, result, params, page, pageSize, summary, elements)
+	bundle := h.buildBundle(h.tenantBaseURL(r.Context()), rt, result, params, page, pageSize, summary, elements)
 	writeFHIR(w, r, http.StatusOK, bundle)
 }
 
-func (h *fhirHandler) buildBundle(rt string, result store.SearchResult, params map[string][]string, page, pageSize int, summary string, elements []string) map[string]any {
+func (h *fhirHandler) buildBundle(baseURL, rt string, result store.SearchResult, params map[string][]string, page, pageSize int, summary string, elements []string) map[string]any {
 	if pageSize <= 0 {
 		pageSize = 20
 	}
@@ -341,7 +341,7 @@ func (h *fhirHandler) buildBundle(rt string, result store.SearchResult, params m
 	for _, res := range result.Entries {
 		id, _ := res["id"].(string)
 		entries = append(entries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, rt, id),
+			"fullUrl":  fmt.Sprintf("%s/%s/%s", baseURL, rt, id),
 			"resource": applyProjection(res, summary, elements),
 			"search":   map[string]any{"mode": "match"},
 		})
@@ -350,13 +350,13 @@ func (h *fhirHandler) buildBundle(rt string, result store.SearchResult, params m
 		inclRT, _ := res["resourceType"].(string)
 		id, _ := res["id"].(string)
 		entries = append(entries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, inclRT, id),
+			"fullUrl":  fmt.Sprintf("%s/%s/%s", baseURL, inclRT, id),
 			"resource": applyProjection(res, summary, elements),
 			"search":   map[string]any{"mode": "include"},
 		})
 	}
 
-	base := fmt.Sprintf("%s/%s", h.baseURL, rt)
+	base := fmt.Sprintf("%s/%s", baseURL, rt)
 	links := []any{
 		map[string]any{"relation": "self", "url": base + "?" + pageQuery(params, page, pageSize)},
 		map[string]any{"relation": "first", "url": base + "?" + pageQuery(params, 1, pageSize)},
@@ -544,7 +544,7 @@ func (h *fhirHandler) everything(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entries := []any{map[string]any{
-		"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, rt, id),
+		"fullUrl":  fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), rt, id),
 		"resource": anchor,
 		"search":   map[string]any{"mode": "match"},
 	}}
@@ -585,7 +585,7 @@ func (h *fhirHandler) everything(w http.ResponseWriter, r *http.Request) {
 
 		seen[key] = true
 		entries = append(entries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, inclRT, inclID),
+			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), inclRT, inclID),
 			"resource": res,
 			"search":   map[string]any{"mode": "include"},
 		})
@@ -646,7 +646,7 @@ func (h *fhirHandler) create(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			slog.Debug("conditional create matched existing resource", "resourceType", rt, "id", existingID)
-			w.Header().Set("Location", fmt.Sprintf("%s/%s/%s", h.baseURL, rt, existingID))
+			w.Header().Set("Location", fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), rt, existingID))
 			w.Header().Set("ETag", fmt.Sprintf(`W/"%s"`, versionFromMeta(existing)))
 			writeFHIR(w, r, http.StatusOK, existing)
 			return
@@ -675,7 +675,7 @@ func (h *fhirHandler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id, _ := resource["id"].(string)
-	w.Header().Set("Location", fmt.Sprintf("%s/%s/%s/_history/1", h.baseURL, rt, id))
+	w.Header().Set("Location", fmt.Sprintf("%s/%s/%s/_history/1", h.tenantBaseURL(r.Context()), rt, id))
 	w.Header().Set("ETag", `W/"1"`)
 	writeFHIR(w, r, http.StatusCreated, resource)
 }
@@ -945,7 +945,7 @@ func (h *fhirHandler) conditionalUpdate(w http.ResponseWriter, r *http.Request) 
 		_ = h.store.SyncSearchParameter(r.Context(), resource)
 	}
 	id, _ := resource["id"].(string)
-	w.Header().Set("Location", fmt.Sprintf("%s/%s/%s/_history/1", h.baseURL, rt, id))
+	w.Header().Set("Location", fmt.Sprintf("%s/%s/%s/_history/1", h.tenantBaseURL(r.Context()), rt, id))
 	w.Header().Set("ETag", `W/"1"`)
 	writeFHIR(w, r, http.StatusCreated, resource)
 }
@@ -1004,9 +1004,9 @@ func (h *fhirHandler) history(w http.ResponseWriter, r *http.Request) {
 	for _, e := range entries {
 		rid, _ := e.Resource["id"].(string)
 		bundleEntries = append(bundleEntries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/%s/%s/_history/%d", h.baseURL, rt, rid, e.VersionID),
+			"fullUrl":  fmt.Sprintf("%s/%s/%s/_history/%d", h.tenantBaseURL(r.Context()), rt, rid, e.VersionID),
 			"resource": e.Resource,
-			"request":  map[string]any{"method": e.Operation, "url": fmt.Sprintf("%s/%s/%s", h.baseURL, rt, rid)},
+			"request":  map[string]any{"method": e.Operation, "url": fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), rt, rid)},
 		})
 	}
 
@@ -1066,9 +1066,9 @@ func (h *fhirHandler) serveHistory(w http.ResponseWriter, r *http.Request, rt st
 		}
 		rid, _ := e.Resource["id"].(string)
 		bundleEntries = append(bundleEntries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/%s/%s/_history/%d", h.baseURL, entryRT, rid, e.VersionID),
+			"fullUrl":  fmt.Sprintf("%s/%s/%s/_history/%d", h.tenantBaseURL(r.Context()), entryRT, rid, e.VersionID),
 			"resource": e.Resource,
-			"request":  map[string]any{"method": e.Operation, "url": fmt.Sprintf("%s/%s/%s", h.baseURL, entryRT, rid)},
+			"request":  map[string]any{"method": e.Operation, "url": fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), entryRT, rid)},
 		})
 	}
 
@@ -1082,9 +1082,9 @@ func (h *fhirHandler) serveHistory(w http.ResponseWriter, r *http.Request, rt st
 
 	var base string
 	if rt == "" {
-		base = h.baseURL + "/_history"
+		base = h.tenantBaseURL(r.Context()) + "/_history"
 	} else {
-		base = fmt.Sprintf("%s/%s/_history", h.baseURL, rt)
+		base = fmt.Sprintf("%s/%s/_history", h.tenantBaseURL(r.Context()), rt)
 	}
 	params := map[string][]string(q)
 	links := []any{
@@ -1506,7 +1506,7 @@ func (h *fhirHandler) compartmentSearch(w http.ResponseWriter, r *http.Request) 
 			writeFHIR(w, r, http.StatusOK, map[string]any{
 				"resourceType": "Bundle", "type": "searchset", "total": 1,
 				"entry": []any{map[string]any{
-					"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, ownerType, ownerID),
+					"fullUrl":  fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), ownerType, ownerID),
 					"resource": resource, "search": map[string]any{"mode": "match"},
 				}},
 			})
@@ -1584,7 +1584,7 @@ func (h *fhirHandler) compartmentSearch(w http.ResponseWriter, r *http.Request) 
 	for _, res := range page_entries {
 		id, _ := res["id"].(string)
 		bundleEntries = append(bundleEntries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, targetRT, id),
+			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), targetRT, id),
 			"resource": res,
 			"search":   map[string]any{"mode": "match"},
 		})

--- a/internal/handler/operations.go
+++ b/internal/handler/operations.go
@@ -62,7 +62,7 @@ func (h *fhirHandler) everythingType(w http.ResponseWriter, r *http.Request) {
 		}
 		seen[key] = true
 		entries = append(entries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, irt, iid),
+			"fullUrl":  fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), irt, iid),
 			"resource": res,
 			"search":   map[string]any{"mode": mode},
 		})
@@ -139,7 +139,7 @@ func (h *fhirHandler) lastN(w http.ResponseWriter, r *http.Request) {
 	for _, obs := range result.Entries {
 		id, _ := obs["id"].(string)
 		entries = append(entries, map[string]any{
-			"fullUrl":  fmt.Sprintf("%s/Observation/%s", h.baseURL, id),
+			"fullUrl":  fmt.Sprintf("%s/Observation/%s", h.tenantBaseURL(r.Context()), id),
 			"resource": obs,
 			"search":   map[string]any{"mode": "match"},
 		})
@@ -171,7 +171,7 @@ func (h *fhirHandler) document(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entries := []any{map[string]any{
-		"fullUrl":  fmt.Sprintf("%s/Composition/%s", h.baseURL, id),
+		"fullUrl":  fmt.Sprintf("%s/Composition/%s", h.tenantBaseURL(r.Context()), id),
 		"resource": comp,
 	}}
 	seen := map[string]bool{"Composition/" + id: true}
@@ -199,7 +199,7 @@ func (h *fhirHandler) document(w http.ResponseWriter, r *http.Request) {
 			}
 			seen[key] = true
 			entries = append(entries, map[string]any{
-				"fullUrl":  fmt.Sprintf("%s/%s/%s", h.baseURL, irt, iid),
+				"fullUrl":  fmt.Sprintf("%s/%s/%s", h.tenantBaseURL(r.Context()), irt, iid),
 				"resource": res,
 			})
 			queue = append(queue, ref{irt, iid})

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -17,7 +17,9 @@
 package handler
 
 import (
+	"context"
 	"net/http"
+	"strings"
 	"sync/atomic"
 
 	"github.com/go-chi/chi/v5"
@@ -26,6 +28,7 @@ import (
 
 	"github.com/wso2/fhir-server/internal/obs"
 	"github.com/wso2/fhir-server/internal/searchparam"
+	"github.com/wso2/fhir-server/internal/tenant"
 )
 
 // NewRouter constructs the chi router. validateOnWrite enables profile
@@ -57,62 +60,115 @@ func NewRouter(s StoreAPI, pool *pgxpool.Pool, registry *searchparam.Registry, b
 		}
 	})
 
-	// System-level transaction / batch Bundle, posted to the FHIR base. Registered
-	// without a trailing slash here and with one below so both /fhir/r4 and
-	// /fhir/r4/ are accepted.
-	r.Post("/fhir/r4", h.bundle)
+	// mountFHIR registers the full FHIR REST surface. It is mounted twice (see
+	// below): once at the bare base path and once under a /t/{tenant} prefix, so
+	// the routing tree is defined in exactly one place.
+	mountFHIR := func(r chi.Router) {
+		// System-level transaction / batch Bundle, posted to the FHIR base.
+		// Registered without a trailing slash here and with one below so both
+		// /fhir/r4 and /fhir/r4/ are accepted.
+		r.Post("/fhir/r4", h.bundle)
 
-	r.Route("/fhir/r4", func(r chi.Router) {
-		// Capability statement
-		r.Get("/metadata", h.metadata)
+		r.Route("/fhir/r4", func(r chi.Router) {
+			// Capability statement
+			r.Get("/metadata", h.metadata)
 
-		// System-level history
-		r.Get("/_history", h.systemHistory)
+			// System-level history
+			r.Get("/_history", h.systemHistory)
 
-		// System-level operations
-		r.Post("/$validate", h.validateSystem) // POST [base]/$validate
-		r.Post("/$convert", h.convert)         // POST [base]/$convert
-		r.Get("/$meta", h.metaSystem)          // GET  [base]/$meta
+			// System-level operations
+			r.Post("/$validate", h.validateSystem) // POST [base]/$validate
+			r.Post("/$convert", h.convert)         // POST [base]/$convert
+			r.Get("/$meta", h.metaSystem)          // GET  [base]/$meta
 
-		// System-level transaction / batch Bundle (trailing-slash form)
-		r.Post("/", h.bundle)
+			// System-level transaction / batch Bundle (trailing-slash form)
+			r.Post("/", h.bundle)
 
-		// Per-resource-type routes
-		r.Route("/{resourceType}", func(r chi.Router) {
-			r.Get("/", h.search)
-			r.Post("/", h.create)
-			r.Put("/", h.conditionalUpdate)    // PUT /{type}?<search>
-			r.Delete("/", h.conditionalDelete) // DELETE /{type}?<search>
-			r.Post("/_search", h.searchPost)
-			r.Post("/$validate", h.validate)        // type-level $validate
-			r.Get("/$meta", h.metaType)             // GET /{type}/$meta
-			r.Get("/$everything", h.everythingType) // type-level $everything
-			r.Get("/$lastn", h.lastN)               // GET /Observation/$lastn
-			r.Get("/_history", h.typeHistory)
+			// Per-resource-type routes
+			r.Route("/{resourceType}", func(r chi.Router) {
+				r.Get("/", h.search)
+				r.Post("/", h.create)
+				r.Put("/", h.conditionalUpdate)    // PUT /{type}?<search>
+				r.Delete("/", h.conditionalDelete) // DELETE /{type}?<search>
+				r.Post("/_search", h.searchPost)
+				r.Post("/$validate", h.validate)        // type-level $validate
+				r.Get("/$meta", h.metaType)             // GET /{type}/$meta
+				r.Get("/$everything", h.everythingType) // type-level $everything
+				r.Get("/$lastn", h.lastN)               // GET /Observation/$lastn
+				r.Get("/_history", h.typeHistory)
 
-			r.Route("/{id}", func(r chi.Router) {
-				r.Get("/", h.read)
-				r.Put("/", h.update)
-				r.Patch("/", h.patch)
-				r.Delete("/", h.delete)
-				r.Get("/_history", h.history)
-				r.Get("/_history/{vid}", h.vread)
-				r.Get("/$everything", h.everything)
-				r.Post("/$validate", h.validateInstance) // instance-level $validate
-				r.Get("/$meta", h.metaInstance)          // GET /{type}/{id}/$meta
-				r.Post("/$meta-add", h.metaAdd)          // POST /{type}/{id}/$meta-add
-				r.Post("/$meta-delete", h.metaDelete)    // POST /{type}/{id}/$meta-delete
-				r.Get("/$document", h.document)          // GET /Composition/{id}/$document
+				r.Route("/{id}", func(r chi.Router) {
+					r.Get("/", h.read)
+					r.Put("/", h.update)
+					r.Patch("/", h.patch)
+					r.Delete("/", h.delete)
+					r.Get("/_history", h.history)
+					r.Get("/_history/{vid}", h.vread)
+					r.Get("/$everything", h.everything)
+					r.Post("/$validate", h.validateInstance) // instance-level $validate
+					r.Get("/$meta", h.metaInstance)          // GET /{type}/{id}/$meta
+					r.Post("/$meta-add", h.metaAdd)          // POST /{type}/{id}/$meta-add
+					r.Post("/$meta-delete", h.metaDelete)    // POST /{type}/{id}/$meta-delete
+					r.Get("/$document", h.document)          // GET /Composition/{id}/$document
 
-				// Compartment search: /Patient/{id}/Observation etc.
-				// Determined at runtime by checking if the URL's resourceType
-				// is a known compartment type.
-				r.Get("/{targetResourceType}", h.compartmentSearch)
+					// Compartment search: /Patient/{id}/Observation etc.
+					// Determined at runtime by checking if the URL's resourceType
+					// is a known compartment type.
+					r.Get("/{targetResourceType}", h.compartmentSearch)
+				})
 			})
 		})
+	}
+
+	// Logical multi-tenancy (Option 2): the same FHIR surface is served at the
+	// bare base path (→ the "default" tenant, so single-tenant deployments are
+	// unaffected) and under an explicit /t/{tenant} prefix. resolveTenant places
+	// the active tenant in the request context; the store turns it into the
+	// Postgres app.current_tenant setting that Row-Level Security enforces.
+	r.Group(func(r chi.Router) {
+		r.Use(h.resolveTenant)
+		mountFHIR(r)
+	})
+	r.Route("/t/{tenant}", func(r chi.Router) {
+		r.Use(h.resolveTenant)
+		mountFHIR(r)
 	})
 
 	return r
+}
+
+// tenantBaseURL returns the FHIR service base URL for the request's tenant.
+// For the default tenant it is the configured base URL unchanged; for an
+// explicit tenant it inserts the /t/{tenant} prefix ahead of the /fhir/r4
+// path segment so that generated absolute URLs (Location headers, Bundle
+// fullUrl and pagination links) address the same tenant the client used.
+func (h *fhirHandler) tenantBaseURL(ctx context.Context) string {
+	t := tenant.From(ctx)
+	if t == tenant.Default {
+		return h.baseURL
+	}
+	if i := strings.LastIndex(h.baseURL, "/fhir/r4"); i >= 0 {
+		return h.baseURL[:i] + "/t/" + t + h.baseURL[i:]
+	}
+	return strings.TrimRight(h.baseURL, "/") + "/t/" + t
+}
+
+// resolveTenant derives the active tenant from the {tenant} URL segment (empty
+// on the bare base path → the default tenant) and stores it in the request
+// context. Malformed tenant identifiers are rejected with 404 so they can never
+// reach a query.
+func (h *fhirHandler) resolveTenant(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "tenant")
+		if id == "" {
+			id = tenant.Default
+		} else if !tenant.Valid(id) {
+			operationOutcome(w, http.StatusNotFound, "error", "not-found", "unknown tenant")
+			return
+		}
+		ctx := tenant.WithTenant(r.Context(), id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
 }
 
 type fhirHandler struct {

--- a/internal/index/extractor.go
+++ b/internal/index/extractor.go
@@ -121,7 +121,7 @@ func Delete(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) err
 	batch := &pgx.Batch{}
 	for _, tbl := range tables {
 		batch.Queue(
-			fmt.Sprintf(`DELETE FROM %s WHERE resource_id = $1 AND resource_type = $2`, tbl),
+			fmt.Sprintf(`DELETE FROM %s WHERE resource_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true)`, tbl),
 			resourceID, resourceType,
 		)
 	}
@@ -152,7 +152,7 @@ func (e *Extractor) Queue(batch *pgx.Batch, resourceType, resourceID string, res
 func QueueDelete(batch *pgx.Batch, resourceType, resourceID string) int {
 	tables := []string{"sp_string", "sp_token", "sp_date", "sp_number", "sp_quantity", "sp_uri", "sp_reference"}
 	for _, tbl := range tables {
-		batch.Queue(fmt.Sprintf(`DELETE FROM %s WHERE resource_id = $1 AND resource_type = $2`, tbl), resourceID, resourceType)
+		batch.Queue(fmt.Sprintf(`DELETE FROM %s WHERE resource_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true)`, tbl), resourceID, resourceType)
 	}
 	return len(tables)
 }

--- a/internal/index/extractor_integration_test.go
+++ b/internal/index/extractor_integration_test.go
@@ -46,7 +46,7 @@ func insertResource(t *testing.T, pool *pgxpool.Pool, resourceType, resourceID s
 	_, err = pool.Exec(context.Background(),
 		`INSERT INTO resources (fhir_id, resource_type, resource_json)
 		 VALUES ($1, $2, $3)
-		 ON CONFLICT (fhir_id, resource_type) DO NOTHING`,
+		 ON CONFLICT (tenant_id, resource_type, fhir_id) DO NOTHING`,
 		resourceID, resourceType, raw,
 	)
 	if err != nil {

--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -158,6 +158,10 @@ func (s *Store) executeTransaction(ctx context.Context, baseURL string, entries 
 	}
 	defer tx.Rollback(ctx)
 
+	if err := setTenantTx(ctx, tx); err != nil {
+		return nil, &BundleError{HTTPStatus: 500, Code: "exception", EntryIndex: -1, Diagnostics: err.Error()}
+	}
+
 	results := make([]BundleEntryResult, len(ops))
 	for _, idx := range order {
 		op := ops[idx]
@@ -336,6 +340,11 @@ func (s *Store) executeBatch(ctx context.Context, baseURL string, entries []Bund
 
 		tx, txerr := s.pool.Begin(ctx)
 		if txerr != nil {
+			results[i] = batchFailure(&BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: txerr.Error()})
+			continue
+		}
+		if txerr := setTenantTx(ctx, tx); txerr != nil {
+			tx.Rollback(ctx)
 			results[i] = batchFailure(&BundleError{HTTPStatus: 500, Code: "exception", Diagnostics: txerr.Error()})
 			continue
 		}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/wso2/fhir-server/internal/searchparam"
 	"github.com/wso2/fhir-server/internal/terminology"
 )
@@ -108,9 +107,18 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 		return SearchResult{}, b.err
 	}
 
+	// Acquire a tenant-scoped connection for the search query. _include /
+	// _revinclude below resolve on their own connections (FetchReferences),
+	// so this one is released as soon as the primary result set is fetched.
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return SearchResult{}, err
+	}
+	defer c.Release()
+
 	// _summary=count: only the total is needed, no rows to fetch.
 	if sp.CountOnly {
-		n, err := b.count(ctx, s.pool)
+		n, err := b.count(ctx, c)
 		if err != nil {
 			slog.Error("search count failed", "resourceType", sp.ResourceType, "err", err)
 			return SearchResult{}, err
@@ -123,7 +131,7 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 	if sp.Total == "none" {
 		// _total=none: skip the count entirely, just fetch rows.
 		var err error
-		entries, err = b.fetch(ctx, s.pool, sp.PageSize, offset)
+		entries, err = b.fetch(ctx, c, sp.PageSize, offset)
 		if err != nil {
 			slog.Error("search failed", "resourceType", sp.ResourceType, "err", err)
 			return SearchResult{}, err
@@ -132,7 +140,7 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 	} else {
 		// Default: fetch rows and total in a single query via COUNT(*) OVER().
 		var err error
-		total, entries, err = b.fetchWithCount(ctx, s.pool, sp.PageSize, offset)
+		total, entries, err = b.fetchWithCount(ctx, c, sp.PageSize, offset)
 		if err != nil {
 			slog.Error("search failed", "resourceType", sp.ResourceType, "err", err)
 			return SearchResult{}, err
@@ -257,8 +265,11 @@ func (b *queryBuilder) next(v any) string {
 
 func (b *queryBuilder) writeBase() {
 	rtP := b.next(b.rt)
+	// Tenant scope (defence in depth alongside Row-Level Security): restrict to
+	// the request's tenant via the app.current_tenant setting the store applies
+	// to the connection/transaction. Holds even if the DB role bypasses RLS.
 	b.where.WriteString(fmt.Sprintf(
-		"r.resource_type = %s AND r.is_deleted = FALSE", rtP,
+		"r.tenant_id = current_setting('app.current_tenant', true) AND r.resource_type = %s AND r.is_deleted = FALSE", rtP,
 	))
 }
 
@@ -1240,7 +1251,7 @@ func (b *queryBuilder) spExists(table, param, _ string) string {
 	return fmt.Sprintf("SELECT 1 FROM %s s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s", table, rtP, pP)
 }
 
-func (b *queryBuilder) count(ctx context.Context, pool *pgxpool.Pool) (int, error) {
+func (b *queryBuilder) count(ctx context.Context, pool querier) (int, error) {
 	q := fmt.Sprintf(`SELECT COUNT(*) FROM resources r WHERE %s`, b.where.String())
 	var n int
 	err := pool.QueryRow(ctx, q, b.args...).Scan(&n)
@@ -1291,7 +1302,13 @@ func (s *Store) LastN(ctx context.Context, params map[string][]string, maxN int)
 		b.where.String(), nP,
 	)
 
-	rows, err := s.pool.Query(ctx, q, b.args...)
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return SearchResult{}, err
+	}
+	defer c.Release()
+
+	rows, err := c.Query(ctx, q, b.args...)
 	if err != nil {
 		return SearchResult{}, err
 	}
@@ -1325,7 +1342,7 @@ func (s *Store) LastN(ctx context.Context, params map[string][]string, maxN int)
 	return SearchResult{Total: len(entries), Entries: entries}, nil
 }
 
-func (b *queryBuilder) fetch(ctx context.Context, pool *pgxpool.Pool, limit, offset int) ([]map[string]any, error) {
+func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset int) ([]map[string]any, error) {
 	// Build the ORDER BY before binding LIMIT/OFFSET so the positional args line
 	// up: [where args…, order-by param args…, limit, offset].
 	orderBy := b.orderByClause()
@@ -1369,7 +1386,7 @@ func (b *queryBuilder) fetch(ctx context.Context, pool *pgxpool.Pool, limit, off
 // page size. This saves a round-trip compared to the previous pattern of a
 // separate SELECT COUNT(*) followed by a paginated SELECT; when ORDER BY
 // requires a sort (no covering index), it also halves the scan work.
-func (b *queryBuilder) fetchWithCount(ctx context.Context, pool *pgxpool.Pool, limit, offset int) (int, []map[string]any, error) {
+func (b *queryBuilder) fetchWithCount(ctx context.Context, pool querier, limit, offset int) (int, []map[string]any, error) {
 	orderBy := b.orderByClause()
 	limitP := b.next(limit)
 	offsetP := b.next(offset)
@@ -1488,17 +1505,25 @@ func (s *Store) FetchReferences(ctx context.Context, resourceType, resourceID st
 		q = `SELECT DISTINCT r.resource_json, r.version_id, r.last_updated
 			 FROM sp_reference sr
 			 JOIN resources r ON r.fhir_id = sr.target_id AND r.resource_type = sr.target_type
-			 WHERE sr.resource_id = $1 AND sr.resource_type = $2 AND r.is_deleted = FALSE`
+			 WHERE sr.resource_id = $1 AND sr.resource_type = $2 AND r.is_deleted = FALSE
+			   AND r.tenant_id = current_setting('app.current_tenant', true)`
 		args = []any{resourceID, resourceType}
 	} else {
 		q = `SELECT DISTINCT r.resource_json, r.version_id, r.last_updated
 			 FROM sp_reference sr
 			 JOIN resources r ON r.fhir_id = sr.resource_id AND r.resource_type = sr.resource_type
-			 WHERE sr.target_id = $1 AND sr.target_type = $2 AND r.is_deleted = FALSE`
+			 WHERE sr.target_id = $1 AND sr.target_type = $2 AND r.is_deleted = FALSE
+			   AND r.tenant_id = current_setting('app.current_tenant', true)`
 		args = []any{resourceID, resourceType}
 	}
 
-	rows, err := s.pool.Query(ctx, q, args...)
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Release()
+
+	rows, err := c.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/wso2/fhir-server/internal/index"
 	"github.com/wso2/fhir-server/internal/searchparam"
+	"github.com/wso2/fhir-server/internal/tenant"
 	"github.com/wso2/fhir-server/internal/terminology"
 )
 
@@ -57,6 +58,52 @@ func WithTerminology(tc *terminology.Client) func(*Store) {
 	return func(s *Store) { s.terminology = tc }
 }
 
+// ─── Tenant scoping ─────────────────────────────────────────────────────────
+// Every PHI table (resources, resource_history, sp_*) is guarded by Postgres
+// Row-Level Security keyed on the `app.current_tenant` runtime setting. The
+// store must set it before any such table is touched, otherwise RLS fails
+// closed (reads return nothing; writes violate NOT NULL on tenant_id).
+//
+//   - writes run in a transaction, so they SET LOCAL (scoped to the tx);
+//   - reads run on a pooled connection acquired via tenantConn.
+//
+// The tenant id comes from the request context (tenant.From), defaulting to
+// the "default" tenant for single-tenant deployments.
+
+const (
+	setTenantLocalSQL   = `SELECT set_config('app.current_tenant', $1, true)`  // tx-scoped
+	setTenantSessionSQL = `SELECT set_config('app.current_tenant', $1, false)` // connection-scoped
+)
+
+// setTenantTx applies the request's tenant to a write transaction.
+func setTenantTx(ctx context.Context, tx pgx.Tx) error {
+	_, err := tx.Exec(ctx, setTenantLocalSQL, tenant.From(ctx))
+	return err
+}
+
+// tenantConn acquires a pooled connection with the request's tenant applied,
+// for read paths that run outside a transaction. The caller must Release it;
+// the next acquirer overwrites app.current_tenant before use, so the value
+// never leaks across tenants.
+func (s *Store) tenantConn(ctx context.Context) (*pgxpool.Conn, error) {
+	c, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := c.Exec(ctx, setTenantSessionSQL, tenant.From(ctx)); err != nil {
+		c.Release()
+		return nil, err
+	}
+	return c, nil
+}
+
+// querier is satisfied by both *pgxpool.Pool and *pgxpool.Conn, letting the
+// search query builder run against a tenant-scoped connection.
+type querier interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
 // ─── Create ───────────────────────────────────────────────────────────────────
 
 func (s *Store) Create(ctx context.Context, resourceType string, body map[string]any) (map[string]any, error) {
@@ -65,6 +112,10 @@ func (s *Store) Create(ctx context.Context, resourceType string, body map[string
 		return nil, err
 	}
 	defer tx.Rollback(ctx)
+
+	if err := setTenantTx(ctx, tx); err != nil {
+		return nil, err
+	}
 
 	result, err := s.createInTx(ctx, tx, resourceType, body)
 	if err != nil {
@@ -147,10 +198,16 @@ func (s *Store) Read(ctx context.Context, resourceType, resourceID string) (map[
 	var lastUpdated time.Time
 	var isDeleted bool
 
-	err := s.pool.QueryRow(ctx, `
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Release()
+
+	err = c.QueryRow(ctx, `
 		SELECT resource_json, version_id, last_updated, is_deleted
 		FROM resources
-		WHERE fhir_id = $1 AND resource_type = $2`,
+		WHERE fhir_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true)`,
 		resourceID, resourceType,
 	).Scan(&raw, &versionID, &lastUpdated, &isDeleted)
 	if err != nil {
@@ -177,6 +234,10 @@ func (s *Store) Update(ctx context.Context, resourceType, resourceID string, bod
 		return nil, err
 	}
 	defer tx.Rollback(ctx)
+
+	if err := setTenantTx(ctx, tx); err != nil {
+		return nil, err
+	}
 
 	result, err := s.updateInTx(ctx, tx, resourceType, resourceID, body, ifMatchVersion)
 	if err != nil {
@@ -215,7 +276,7 @@ func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 	batch := &pgx.Batch{}
 	batch.Queue(
 		`UPDATE resources SET version_id = $1, last_updated = $2, resource_json = $3, is_deleted = FALSE
-		 WHERE fhir_id = $4 AND resource_type = $5`,
+		 WHERE fhir_id = $4 AND resource_type = $5 AND tenant_id = current_setting('app.current_tenant', true)`,
 		newVersion, lastUpdated, raw, resourceID, resourceType,
 	)
 	nDeletes := index.QueueDelete(batch, resourceType, resourceID) // nDeletes DELETEs at positions 1-nDeletes
@@ -267,6 +328,10 @@ func (s *Store) Patch(ctx context.Context, resourceType, resourceID string, patc
 	}
 	defer tx.Rollback(ctx)
 
+	if err := setTenantTx(ctx, tx); err != nil {
+		return nil, err
+	}
+
 	merged, newVersion, err := s.patchInTx(ctx, tx, resourceType, resourceID, patch)
 	if err != nil {
 		return nil, err
@@ -289,7 +354,7 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 	var isDeleted bool
 	if err := tx.QueryRow(ctx, `
 		SELECT resource_json, version_id, last_updated, is_deleted
-		FROM resources WHERE fhir_id = $1 AND resource_type = $2 FOR UPDATE`,
+		FROM resources WHERE fhir_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true) FOR UPDATE`,
 		resourceID, resourceType,
 	).Scan(&raw, &versionID, &lastUpdated, &isDeleted); err != nil {
 		if isNoRows(err) {
@@ -321,7 +386,7 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 	batch := &pgx.Batch{}
 	batch.Queue(
 		`UPDATE resources SET version_id = $1, last_updated = $2, resource_json = $3, is_deleted = FALSE
-		 WHERE fhir_id = $4 AND resource_type = $5`,
+		 WHERE fhir_id = $4 AND resource_type = $5 AND tenant_id = current_setting('app.current_tenant', true)`,
 		newVersion, now, mergedRaw, resourceID, resourceType,
 	)
 	nDeletes := index.QueueDelete(batch, resourceType, resourceID)
@@ -392,6 +457,10 @@ func (s *Store) Delete(ctx context.Context, resourceType, resourceID string) err
 	}
 	defer tx.Rollback(ctx)
 
+	if err := setTenantTx(ctx, tx); err != nil {
+		return err
+	}
+
 	if err := s.deleteInTx(ctx, tx, resourceType, resourceID); err != nil {
 		return err
 	}
@@ -417,7 +486,7 @@ func (s *Store) deleteInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 	var isDeleted bool
 	if err := tx.QueryRow(ctx, `
 		SELECT resource_json, version_id, last_updated, is_deleted
-		FROM resources WHERE fhir_id = $1 AND resource_type = $2 FOR UPDATE`,
+		FROM resources WHERE fhir_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true) FOR UPDATE`,
 		resourceID, resourceType,
 	).Scan(&raw, &versionID, &lastUpdated, &isDeleted); err != nil {
 		if isNoRows(err) {
@@ -439,7 +508,7 @@ func (s *Store) deleteInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 	nDeletes := index.QueueDelete(batch, resourceType, resourceID) // nDeletes DELETEs
 	batch.Queue(
 		`UPDATE resources SET is_deleted = TRUE, version_id = $1, last_updated = $2
-		 WHERE fhir_id = $3 AND resource_type = $4`,
+		 WHERE fhir_id = $3 AND resource_type = $4 AND tenant_id = current_setting('app.current_tenant', true)`,
 		deleteVersion, now, resourceID, resourceType,
 	)
 
@@ -470,7 +539,13 @@ type HistoryEntry struct {
 }
 
 func (s *Store) GetHistory(ctx context.Context, resourceType, resourceID string) ([]HistoryEntry, error) {
-	rows, err := s.pool.Query(ctx, `
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Release()
+
+	rows, err := c.Query(ctx, `
 		SELECT version_id, operation, resource_json, recorded_at
 		FROM resource_history
 		WHERE resource_type = $1 AND fhir_id = $2
@@ -543,7 +618,13 @@ func (s *Store) GetTypeHistory(ctx context.Context, p HistoryParams) (HistoryRes
 		args = []any{p.ResourceType, p.Since}
 	}
 
-	if err := s.pool.QueryRow(ctx, countQ, args...).Scan(&total); err != nil {
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return HistoryResult{}, err
+	}
+	defer c.Release()
+
+	if err := c.QueryRow(ctx, countQ, args...).Scan(&total); err != nil {
 		return HistoryResult{}, err
 	}
 
@@ -551,7 +632,7 @@ func (s *Store) GetTypeHistory(ctx context.Context, p HistoryParams) (HistoryRes
 	fetchArgs := make([]any, len(args), len(args)+2)
 	copy(fetchArgs, args)
 	fetchArgs = append(fetchArgs, p.PageSize, offset)
-	rows, err := s.pool.Query(ctx, fetchQ, fetchArgs...)
+	rows, err := c.Query(ctx, fetchQ, fetchArgs...)
 	if err != nil {
 		return HistoryResult{}, err
 	}
@@ -567,7 +648,12 @@ func (s *Store) GetTypeHistory(ctx context.Context, p HistoryParams) (HistoryRes
 func (s *Store) GetVersion(ctx context.Context, resourceType, resourceID string, versionID int) (map[string]any, error) {
 	var raw []byte
 	var recordedAt time.Time
-	err := s.pool.QueryRow(ctx, `
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Release()
+	err = c.QueryRow(ctx, `
 		SELECT resource_json, recorded_at FROM resource_history
 		WHERE resource_type = $1 AND fhir_id = $2 AND version_id = $3`,
 		resourceType, resourceID, versionID,
@@ -614,7 +700,7 @@ func (s *Store) readInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceI
 	var isDeleted bool
 	if err := tx.QueryRow(ctx, `
 		SELECT resource_json, version_id, last_updated, is_deleted
-		FROM resources WHERE fhir_id = $1 AND resource_type = $2`,
+		FROM resources WHERE fhir_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true)`,
 		resourceID, resourceType,
 	).Scan(&raw, &versionID, &lastUpdated, &isDeleted); err != nil {
 		if isNoRows(err) {
@@ -630,7 +716,7 @@ func (s *Store) readInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceI
 
 func bumpVersion(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) (newVersion, currentVersion int, lastUpdated time.Time, err error) {
 	if err = tx.QueryRow(ctx, `
-		SELECT version_id FROM resources WHERE fhir_id = $1 AND resource_type = $2 FOR UPDATE`,
+		SELECT version_id FROM resources WHERE fhir_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true) FOR UPDATE`,
 		resourceID, resourceType,
 	).Scan(&currentVersion); err != nil {
 		if isNoRows(err) {
@@ -811,8 +897,13 @@ func (s *Store) SyncSearchParameter(ctx context.Context, body map[string]any) er
 // DeleteSearchParameter removes a custom SearchParameter by resource ID.
 func (s *Store) DeleteSearchParameter(ctx context.Context, resourceID string) error {
 	var raw []byte
-	err := s.pool.QueryRow(ctx,
-		`SELECT resource_json FROM resources WHERE fhir_id = $1 AND resource_type = 'SearchParameter'`,
+	c, err := s.tenantConn(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.Release()
+	err = c.QueryRow(ctx,
+		`SELECT resource_json FROM resources WHERE fhir_id = $1 AND resource_type = 'SearchParameter' AND tenant_id = current_setting('app.current_tenant', true)`,
 		resourceID,
 	).Scan(&raw)
 	if err != nil {

--- a/internal/store/tenant_integration_test.go
+++ b/internal/store/tenant_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package store_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wso2/fhir-server/internal/db"
+	"github.com/wso2/fhir-server/internal/store"
+	"github.com/wso2/fhir-server/internal/tenant"
+	"github.com/wso2/fhir-server/internal/testutil"
+)
+
+// appRoleStore returns a Store backed by a NON-superuser role. Tenant isolation
+// is enforced by PostgreSQL Row-Level Security, which superusers (and the
+// default testcontainers role) bypass — so a faithful isolation test must
+// connect as an ordinary role, exactly as a production deployment should.
+func appRoleStore(t *testing.T) *store.Store {
+	t.Helper()
+	ctx := context.Background()
+	admin := testutil.MustSeededDB(t)
+	reg := testutil.MustRegistry(t, admin)
+
+	for _, stmt := range []string{
+		`DO $$ BEGIN
+			IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fhir_app') THEN
+				CREATE ROLE fhir_app LOGIN PASSWORD 'app';
+			END IF;
+		END $$;`,
+		`GRANT USAGE ON SCHEMA public TO fhir_app`,
+		`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO fhir_app`,
+		`GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO fhir_app`,
+	} {
+		if _, err := admin.Exec(ctx, stmt); err != nil {
+			t.Fatalf("provision app role (%q): %v", stmt, err)
+		}
+	}
+
+	cc := admin.Config().ConnConfig
+	dsn := fmt.Sprintf("postgres://fhir_app:app@%s:%d/%s?sslmode=disable", cc.Host, cc.Port, cc.Database)
+	appPool, err := db.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect as app role: %v", err)
+	}
+	t.Cleanup(appPool.Close)
+	return store.New(appPool, reg)
+}
+
+// TestTenantIsolation verifies the Option 2 logical-separation guarantees: two
+// tenants can hold resources with the same id, neither can read the other's
+// data, and searches are scoped to the calling tenant.
+func TestTenantIsolation(t *testing.T) {
+	s := appRoleStore(t)
+
+	ctxA := tenant.WithTenant(context.Background(), "tenant-a")
+	ctxB := tenant.WithTenant(context.Background(), "tenant-b")
+
+	// Both tenants create a Patient with the SAME client-assigned id.
+	const id = "shared-id-1"
+	mkPatient := func(family string) map[string]any {
+		return map[string]any{
+			"resourceType": "Patient",
+			"id":           id,
+			"name":         []any{map[string]any{"family": family}},
+		}
+	}
+	if _, err := s.Create(ctxA, "Patient", mkPatient("Anderson")); err != nil {
+		t.Fatalf("tenant-a create: %v", err)
+	}
+	if _, err := s.Create(ctxB, "Patient", mkPatient("Becker")); err != nil {
+		t.Fatalf("tenant-b create (same id must be allowed across tenants): %v", err)
+	}
+
+	// Each tenant reads back its OWN resource.
+	a, err := s.Read(ctxA, "Patient", id)
+	if err != nil {
+		t.Fatalf("tenant-a read: %v", err)
+	}
+	if got := familyName(a); got != "Anderson" {
+		t.Fatalf("tenant-a read returned family %q, want Anderson", got)
+	}
+	b, err := s.Read(ctxB, "Patient", id)
+	if err != nil {
+		t.Fatalf("tenant-b read: %v", err)
+	}
+	if got := familyName(b); got != "Becker" {
+		t.Fatalf("tenant-b read returned family %q, want Becker", got)
+	}
+
+	// A third tenant sees nothing.
+	ctxC := tenant.WithTenant(context.Background(), "tenant-c")
+	if _, err := s.Read(ctxC, "Patient", id); !errors.As(err, &store.NotFoundError{}) {
+		t.Fatalf("tenant-c read: want NotFoundError, got %v", err)
+	}
+
+	// Search is tenant-scoped: tenant-a matches only its own Patient.
+	res, err := s.Search(ctxA, store.SearchParams{
+		ResourceType: "Patient",
+		Params:       map[string][]string{"family": {"Anderson"}},
+	})
+	if err != nil {
+		t.Fatalf("tenant-a search: %v", err)
+	}
+	if res.Total != 1 {
+		t.Fatalf("tenant-a search total = %d, want 1", res.Total)
+	}
+	// tenant-b must not see tenant-a's "Anderson".
+	resB, err := s.Search(ctxB, store.SearchParams{
+		ResourceType: "Patient",
+		Params:       map[string][]string{"family": {"Anderson"}},
+	})
+	if err != nil {
+		t.Fatalf("tenant-b search: %v", err)
+	}
+	if resB.Total != 0 {
+		t.Fatalf("tenant-b search for tenant-a data total = %d, want 0 (cross-tenant leak)", resB.Total)
+	}
+
+	// Deleting in tenant-a must not affect tenant-b's identically-keyed resource.
+	if err := s.Delete(ctxA, "Patient", id); err != nil {
+		t.Fatalf("tenant-a delete: %v", err)
+	}
+	if _, err := s.Read(ctxA, "Patient", id); !errors.As(err, &store.GoneError{}) {
+		t.Fatalf("tenant-a read after delete: want GoneError, got %v", err)
+	}
+	if _, err := s.Read(ctxB, "Patient", id); err != nil {
+		t.Fatalf("tenant-b read after tenant-a delete must still succeed: %v", err)
+	}
+}
+
+func familyName(resource map[string]any) string {
+	names, _ := resource["name"].([]any)
+	if len(names) == 0 {
+		return ""
+	}
+	n, _ := names[0].(map[string]any)
+	fam, _ := n["family"].(string)
+	return fam
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package tenant carries the active tenant identifier through a request's
+// context. In the logical multi-tenancy model (Option 2) every request is
+// attributed to exactly one tenant; the store layer turns that identifier into
+// the Postgres `app.current_tenant` setting that Row-Level Security policies
+// key on. Deployments that run one server/database per tenant (Option 1) can
+// ignore tenancy entirely — requests fall back to the Default tenant.
+package tenant
+
+import (
+	"context"
+	"regexp"
+)
+
+// Default is the tenant assigned to requests that do not carry an explicit
+// tenant (e.g. the legacy /fhir/r4 base path). Single-tenant deployments
+// therefore keep working unchanged: all of their data lives under "default".
+const Default = "default"
+
+// validID constrains tenant identifiers to a conservative, URL- and
+// SQL-safe character set. It also bounds the length so a tenant id cannot be
+// used to smuggle arbitrary text into the `app.current_tenant` setting.
+var validID = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`)
+
+type ctxKey struct{}
+
+// WithTenant returns a copy of ctx that carries the given tenant id.
+func WithTenant(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, id)
+}
+
+// From returns the tenant id carried by ctx, or Default if none is set.
+func From(ctx context.Context) string {
+	if id, ok := ctx.Value(ctxKey{}).(string); ok && id != "" {
+		return id
+	}
+	return Default
+}
+
+// Valid reports whether id is a well-formed tenant identifier.
+func Valid(id string) bool {
+	return validID.MatchString(id)
+}

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
@@ -59,11 +60,26 @@ func MustDB(t *testing.T) *pgxpool.Pool {
 		t.Fatalf("get connection string: %v", err)
 	}
 
-	pool, err := db.Connect(ctx, connStr)
+	// Default every connection to the "default" tenant. Tests that drive the
+	// store set the tenant per request and override this; tests that write via
+	// raw SQL still need a tenant for the tenant_id column default and the
+	// Row-Level Security policies added in schema v6.
+	cfg, err := pgxpool.ParseConfig(connStr)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	cfg.AfterConnect = func(ctx context.Context, c *pgx.Conn) error {
+		_, err := c.Exec(ctx, "SET app.current_tenant = 'default'")
+		return err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
 	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
 
 	if err := db.Migrate(ctx, pool); err != nil {
 		t.Fatalf("migrate: %v", err)


### PR DESCRIPTION
## What

Adds **multi-tenancy** to the FHIR server, supporting two models that can be used independently or together.

### Option 2 — Logical separation (implemented in code)
One server + one database serve all tenants; isolation is enforced by **PostgreSQL Row-Level Security**.

- **Tenant in the URL.** `/t/{tenant}/fhir/r4/...` addresses a named tenant; the bare `/fhir/r4/...` base maps to a `default` tenant, so **existing single-tenant deployments keep working unchanged**.
- **DB-enforced isolation.** The store sets `app.current_tenant` per write-transaction (`SET LOCAL`) and per read-connection. RLS policies on `resources`, `resource_history`, and the `sp_*` index tables restrict every read/write to the matching `tenant_id`. New rows derive `tenant_id` from the same setting and fail closed when unset. Explicit tenant predicates are added as defense in depth.
- **Schema v6** (idempotent, version-gated): adds `tenant_id`, re-keys PK/FKs by tenant, enables + forces RLS, and **backfills existing rows to `default`**.
- **Per-request base URLs** so `Location`, Bundle `fullUrl`, and pagination links carry the `/t/{tenant}` prefix.

### Option 1 — Physical separation (deployment only)
One server/database per tenant behind a gateway — **no application changes required**; each instance is a normal single-tenant server.

## Scope / notes

- PHI tables are tenant-scoped; the **search-parameter registry and IGs remain shared** across tenants (documented).
- ⚠️ **The DB role must not be a superuser** — superusers/`BYPASSRLS` bypass RLS. The server should run behind an authenticating gateway (it trusts the tenant in the URL) and connect as a least-privilege role. Both points are documented in the README.

## Testing

- `go build`, `go vet`, unit tests, and the full `-tags integration` store + handler suites pass.
- New **`TestTenantIsolation`** (integration) connects as a **non-superuser** role and verifies: two tenants can hold the same resource id, neither can read/search/delete the other's data, and a third tenant sees nothing.

## Files

- `internal/tenant/` — tenant-in-context (+ `default` fallback, id validation)
- `internal/db/schema.sql` — v6 migration + RLS
- `internal/store/*` — tenant GUC plumbing + predicates
- `internal/handler/router.go` — tenant routing + per-request base URL
- `README.md` — Multi-Tenancy section (both models, non-superuser requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)