### PR TITLE
Improve onboarding docs and make DB table creation opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ curl -s -X POST http://localhost:9090/fhir/r4/Patient \
 The server is available at **`http://localhost:9090/fhir/r4`**.  
 PostgreSQL is exposed on `localhost:5432` (user `fhir`, password `fhir`, database `fhirdb`).
 
+**Explore the database:** the compose stack includes [Adminer](https://www.adminer.org/),
+a lightweight web UI, at **`http://localhost:8080`**. Log in with:
+
+| Field    | Value        |
+|----------|--------------|
+| System   | `PostgreSQL` |
+| Server   | `db`         |
+| Username | `fhir`       |
+| Password | `fhir`       |
+| Database | `fhirdb`     |
+
 To stop and remove all data:
 ```bash
 docker-compose down -v

--- a/README.md
+++ b/README.md
@@ -100,7 +100,17 @@ export DB_PASSWORD="$(cat ~/.fhir-db-password)"
 go run ./cmd/server --config ./config.yaml
 ```
 
-Schema migrations run automatically at startup.
+The server does **not** create database tables by default — that needs a role
+with DDL privileges, which the runtime DB role usually should not have. To
+create the tables (e.g. on first start, when the role owns the database), opt
+in with `FHIR_CREATE_TABLES=true`:
+
+```bash
+FHIR_CREATE_TABLES=true go run ./cmd/server      # creates tables, then serves
+```
+
+Otherwise the server expects the tables to already exist and logs that it is
+skipping table creation. (The `docker-compose` setup sets this for you.)
 
 The server logs a JSON line to stdout when listening:
 ```json
@@ -195,6 +205,7 @@ ig:
 | `database.user` | `DB_USER` | `fhir` | PostgreSQL user |
 | `database.password` | `DB_PASSWORD` | `fhir` | PostgreSQL password |
 | `database.name` | `DB_NAME` | `fhirdb` | PostgreSQL database name |
+| `database.createTables` | `FHIR_CREATE_TABLES` | `false` | Create the server's tables on startup. Requires a DB role with DDL privileges, so it is off by default; enable it for a one-off first start, or create tables out-of-band with a privileged role. |
 | `ig.packages` | `IG_PACKAGES` | *(empty)* | List of IG package specs to load at startup. In env vars, comma-separated. See [Implementation Guides](#10-implementation-guides). |
 | `ig.registryUrl` | `IG_REGISTRY_URL` | `https://packages.fhir.org` | FHIR package registry for resolving `name@version` specs. |
 | `ig.forceReload` | `IG_FORCE_RELOAD` | `false` | Set to `true` to re-download and re-process IGs even if already recorded in the database. |
@@ -213,7 +224,7 @@ ig:
 cmd/server/main.go           Entry point: wires all packages, starts HTTP
 │
 ├── internal/config          Reads env vars, validates, provides typed Config struct
-├── internal/db              Opens pgxpool, runs idempotent schema migrations
+├── internal/db              Opens pgxpool, creates schema tables on opt-in (idempotent)
 ├── internal/seed            Inserts 100+ base FHIR R4 search param definitions (idempotent)
 ├── internal/searchparam     Thread-safe registry: resource type + param name → FHIRPath + type
 ├── internal/fhirpath        FHIRPath evaluator (path chains, where(), ofType(), arrays)
@@ -280,7 +291,7 @@ store.Search
 ```
 1. Load config from env
 2. Connect to PostgreSQL (pgxpool)
-3. Run schema migrations (idempotent CREATE TABLE IF NOT EXISTS)
+3. Create schema tables if FHIR_CREATE_TABLES=true (idempotent CREATE TABLE IF NOT EXISTS); otherwise skip
 4. Seed base FHIR R4 search params (ON CONFLICT DO NOTHING)
 5. Load search param registry from DB
 6. Create store + HTTP router
@@ -350,7 +361,7 @@ The `resources`, `resource_history`, and `sp_*` indexes lead with `tenant_id`, s
 
 ## 6. Database Schema
 
-The schema is embedded in the binary (`internal/db/schema.sql`, schema version 6) and applied at startup via `db.Migrate()`. It describes the database from scratch — every PHI table carries a `tenant_id` column and tenant-leading primary/foreign keys, and Row-Level Security is declared on each (see [Multi-Tenancy](#5-multi-tenancy)). Statements use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` so a fresh database can be (re)initialised safely. Upgrading a pre-existing database to a new schema version is handled by a separate migration step.
+The schema is embedded in the binary (`internal/db/schema.sql`, schema version 6). It describes the database from scratch — every PHI table carries a `tenant_id` column and tenant-leading primary/foreign keys, and Row-Level Security is declared on each (see [Multi-Tenancy](#5-multi-tenancy)). It is applied at startup by `db.CreateTables()` **only when `FHIR_CREATE_TABLES=true`** (off by default — see [Running Without Docker](#2-running-without-docker)). This is table creation, not a migration system: statements use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`, so a fresh database can be (re)initialised safely but it can only add tables/columns — it cannot perform destructive or altering changes. Upgrading a pre-existing database to a new schema version is handled by a separate migration step.
 
 ### Core tables
 
@@ -915,4 +926,4 @@ Add a corresponding test case in `internal/handler/handler_test.go`.
 
 ### Updating the schema
 
-Add new statements to `internal/db/schema.sql`. Use `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` so the migration is idempotent. Bump the version number in the final `INSERT INTO schema_version` statement.
+Add new statements to `internal/db/schema.sql`. Use `CREATE TABLE IF NOT EXISTS` and `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` so table creation stays idempotent. Bump the version number in the final `INSERT INTO schema_version` statement.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ docker-compose up
 # 2. Wait for the server to report healthy (watch the container logs or poll):
 curl -sv http://localhost:9090/health/ready   # → look for "< HTTP/1.1 200 OK" when ready (body is empty)
 
-# 3. Smoke test — create a Patient
+# 3. Smoke test — create a Patient. The server assigns an id and returns the
+#    created resource; piping to `jq .id` prints just the new Patient's id, e.g.:
+#      "abeab77a-34e5-4fd5-b5df-8c2ce4691682"
 curl -s -X POST http://localhost:9090/fhir/r4/Patient \
   -H "Content-Type: application/fhir+json" \
   -d '{"resourceType":"Patient","name":[{"family":"Smith","given":["Alice"]}]}' \

--- a/README.md
+++ b/README.md
@@ -71,9 +71,19 @@ docker-compose down -v
 **Prerequisites:** Go 1.25+, PostgreSQL 13+ running locally
 
 ```bash
-# Create the database
-psql -U postgres -c "CREATE USER fhir WITH PASSWORD 'fhir';"
-psql -U postgres -c "CREATE DATABASE fhirdb OWNER fhir;"
+# Create the role and database as a PostgreSQL superuser.
+# Pick the block that matches how you installed PostgreSQL:
+
+# --- macOS (Homebrew) ---
+# Your OS user is the superuser; there is no "postgres" role, so connect
+# with `psql postgres`. (Using `-U postgres` fails: role "postgres" does not exist.)
+psql postgres -c "CREATE USER fhir WITH PASSWORD 'fhir';"
+psql postgres -c "CREATE DATABASE fhirdb OWNER fhir;"
+
+# --- Debian / Ubuntu / RHEL (apt/yum packages) ---
+# The superuser is the "postgres" OS/DB role; run psql via sudo -u postgres.
+sudo -u postgres psql -c "CREATE USER fhir WITH PASSWORD 'fhir';"
+sudo -u postgres psql -c "CREATE DATABASE fhirdb OWNER fhir;"
 
 # Option A — point the server at a YAML config file
 cp config.example.yaml config.yaml      # then edit as needed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A FHIR R4 REST server written in Go, backed by PostgreSQL. It replaces a legacy 
 docker-compose up
 
 # 2. Wait for the server to report healthy (watch the container logs or poll):
-curl -s http://localhost:9090/health/ready   # → 200 OK when ready
+curl -sv http://localhost:9090/health/ready   # → look for "< HTTP/1.1 200 OK" when ready (body is empty)
 
 # 3. Smoke test — create a Patient
 curl -s -X POST http://localhost:9090/fhir/r4/Patient \

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,7 +41,7 @@ Run with `go test -tags integration -timeout 300s <package>`. Requires Docker.
 
 | Package | Tests | What is covered |
 |---|---|---|
-| `internal/db` | 3 | `Migrate` creates all 12 expected tables; `search_param_definitions` has all required columns; migration is idempotent |
+| `internal/db` | 3 | `CreateTables` creates all 12 expected tables; `search_param_definitions` has all required columns; table creation is idempotent |
 | `internal/seed` | 4 | `SeedSearchParams` inserts ≥100 FHIR R4 base params; seeding is idempotent; 8 known params are present; all 5 param types exist |
 | `internal/store` | ~30 | Full CRUD lifecycle (create→read→update→patch→delete); version history; pagination; search by string/token/date params; `_id` search; deleted resources excluded; `FetchReferences` forward and reverse; `SearchParameter` sync and delete |
 | `internal/index` | 6 | `Extractor.Index` writes to `sp_string`, `sp_token`, `sp_date`, `sp_reference`; CodeableConcept token extraction; `Delete` clears all `sp_*` tables for a resource |
@@ -51,7 +51,7 @@ Run with `go test -tags integration -timeout 300s <package>`. Requires Docker.
 
 Integration tests share a test helper in `internal/testutil/postgres.go` (build tag: `integration`):
 
-- **`MustDB(t)`** — starts a fresh `postgres:16-alpine` container, runs `db.Migrate`, returns a pool; container terminates on `t.Cleanup`.
+- **`MustDB(t)`** — starts a fresh `postgres:16-alpine` container, runs `db.CreateTables`, returns a pool; container terminates on `t.Cleanup`.
 - **`MustSeededDB(t)`** — like `MustDB` but also runs `seed.SeedSearchParams`.
 - **`MustRegistry(t, pool)`** — loads a `searchparam.Registry` from the pool.
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -78,9 +78,17 @@ func run() error {
 	defer pool.Close()
 	slog.Info("connected to database")
 
-	slog.Info("starting database migration")
-	if err := db.Migrate(ctx, pool); err != nil {
-		return fmt.Errorf("migrate: %w", err)
+	// Table creation is opt-in: it needs a DB role with DDL privileges, which
+	// the runtime role usually should not have. When disabled (the default),
+	// the tables are expected to already exist.
+	if cfg.CreateTables {
+		slog.Info("creating database tables")
+		if err := db.CreateTables(ctx, pool); err != nil {
+			return fmt.Errorf("create tables: %w", err)
+		}
+	} else {
+		slog.Info("skipping database table creation; expecting tables to already exist " +
+			"(set FHIR_CREATE_TABLES=true or database.createTables to create them)")
 	}
 
 	// Seed standard FHIR R4 search parameters (idempotent — ON CONFLICT DO NOTHING)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -34,6 +34,11 @@ database:
   # user: fhir
   # password: fhir
   # name: fhirdb
+  # Create the server's tables on startup. Off by default because it needs a
+  # DB role with DDL privileges — the runtime role usually should not have
+  # those. Enable it for a one-off first start, or create tables out-of-band
+  # with a privileged role. Env equivalent: FHIR_CREATE_TABLES=true.
+  # createTables: false
 
 ig:
   # Implementation guides to load at startup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,20 @@ services:
       timeout: 5s
       retries: 10
 
+  # Lightweight web UI for browsing the database. Open http://localhost:8080
+  # and log in with System: PostgreSQL, Server: db, User: fhir, Password: fhir,
+  # Database: fhirdb.
+  adminer:
+    image: adminer:4
+    ports:
+      - "8080:8080"
+    environment:
+      ADMINER_DEFAULT_SERVER: db
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: on-failure
+
   server:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       - "9090:9090"
     environment:
       DATABASE_URL: postgres://fhir:fhir@db:5432/fhirdb?sslmode=disable&pool_max_conns=20
+      # The bundled `fhir` user owns fhirdb and has DDL rights, so let the
+      # server create its tables on first start. In production, create tables
+      # out-of-band with a privileged role and leave this unset (default off).
+      FHIR_CREATE_TABLES: "true"
       SERVER_PORT: "9090"
       BASE_URL: http://localhost:9090/fhir/r4
       LOG_LEVEL: info

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	IGCacheDir      string   // local .tgz cache dir (default: .fhir-ig-cache)
 	ValidateOnWrite bool     // enforce profile validation on create/update (default off)
 	TerminologyURL  string   // base URL of the FHIR terminology server for :in/:not-in (empty = disabled)
+	CreateTables    bool     // create database tables on startup (requires a DB role with DDL privileges; default off)
 
 	// HTTP server timeouts. WriteTimeout bounds the WHOLE handler execution in
 	// net/http, so it must accommodate the slowest legitimate request (e.g. a
@@ -80,6 +81,9 @@ type FileConfig struct {
 		User     string `yaml:"user"`
 		Password string `yaml:"password"`
 		Name     string `yaml:"name"`
+		// CreateTables opts in to creating the schema's tables on startup.
+		// Pointer so an absent key is distinguishable from an explicit `false`.
+		CreateTables *bool `yaml:"createTables"`
 	} `yaml:"database"`
 
 	IG struct {
@@ -151,6 +155,14 @@ func resolve(fc *FileConfig) (*Config, error) {
 	validateOnWrite := strings.EqualFold(os.Getenv("FHIR_VALIDATE_ON_WRITE"), "true")
 	terminologyURL := os.Getenv("FHIR_TERMINOLOGY_URL")
 
+	createTables := false
+	if fc.Database.CreateTables != nil {
+		createTables = *fc.Database.CreateTables
+	}
+	if v := os.Getenv("FHIR_CREATE_TABLES"); v != "" {
+		createTables = strings.EqualFold(v, "true")
+	}
+
 	readTimeout, err := resolveTimeout("SERVER_READ_TIMEOUT", "server.readTimeout", fc.Server.ReadTimeout, 30*time.Second)
 	if err != nil {
 		return nil, err
@@ -175,6 +187,7 @@ func resolve(fc *FileConfig) (*Config, error) {
 		IGCacheDir:      igCacheDir,
 		ValidateOnWrite: validateOnWrite,
 		TerminologyURL:  terminologyURL,
+		CreateTables:    createTables,
 		ReadTimeout:     readTimeout,
 		WriteTimeout:    writeTimeout,
 		IdleTimeout:     idleTimeout,

--- a/internal/conformance/harness_test.go
+++ b/internal/conformance/harness_test.go
@@ -102,8 +102,8 @@ func runWithContainer(m *testing.M) int {
 		return 1
 	}
 	defer pool.Close()
-	if err := db.Migrate(ctx, pool); err != nil {
-		fmt.Fprintln(os.Stderr, "migrate:", err)
+	if err := db.CreateTables(ctx, pool); err != nil {
+		fmt.Fprintln(os.Stderr, "create tables:", err)
 		return 1
 	}
 	if err := seed.SeedSearchParams(ctx, pool); err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -47,7 +47,15 @@ func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	return pool, nil
 }
 
-func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
+// CreateTables applies the embedded schema.sql to the database, creating the
+// tables and indexes the server needs if they do not already exist.
+//
+// This is NOT a migration system: schema.sql is purely additive (CREATE TABLE
+// IF NOT EXISTS / ADD COLUMN IF NOT EXISTS), so it cannot perform destructive
+// or altering schema changes. Applying it requires a database role with DDL
+// privileges, so the server only calls it when explicitly opted in (see the
+// CreateTables config / FHIR_CREATE_TABLES env var).
+func CreateTables(ctx context.Context, pool *pgxpool.Pool) error {
 	schema, err := schemaFS.ReadFile("schema.sql")
 	if err != nil {
 		return fmt.Errorf("read embedded schema: %w", err)
@@ -58,6 +66,6 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
 		return fmt.Errorf("apply schema: %w", err)
 	}
 
-	slog.Info("schema migration complete")
+	slog.Info("database tables created")
 	return nil
 }

--- a/internal/db/db_integration_test.go
+++ b/internal/db/db_integration_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/wso2/fhir-server/internal/testutil"
 )
 
-func TestMigrate_CreatesExpectedTables(t *testing.T) {
-	pool := testutil.MustDB(t) // MustDB already runs Migrate
+func TestCreateTables_CreatesExpectedTables(t *testing.T) {
+	pool := testutil.MustDB(t) // MustDB already runs CreateTables
 	ctx := context.Background()
 
 	tables := []string{
@@ -56,24 +56,24 @@ func TestMigrate_CreatesExpectedTables(t *testing.T) {
 			t.Fatalf("query table %q: %v", tbl, err)
 		}
 		if !exists {
-			t.Errorf("table %q not created by migration", tbl)
+			t.Errorf("table %q not created by CreateTables", tbl)
 		}
 	}
 }
 
-func TestMigrate_Idempotent(t *testing.T) {
+func TestCreateTables_Idempotent(t *testing.T) {
 	pool := testutil.MustDB(t)
 	ctx := context.Background()
 
-	// MustDB already ran Migrate once; query to confirm tables are usable.
+	// MustDB already ran CreateTables once; query to confirm tables are usable.
 	var n int
 	err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM resources`).Scan(&n)
 	if err != nil {
-		t.Fatalf("query after double migrate: %v", err)
+		t.Fatalf("query after table creation: %v", err)
 	}
 }
 
-func TestMigrate_SearchParamDefinitions_HasColumns(t *testing.T) {
+func TestCreateTables_SearchParamDefinitions_HasColumns(t *testing.T) {
 	pool := testutil.MustDB(t)
 	ctx := context.Background()
 

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -33,8 +33,8 @@ import (
 	"github.com/wso2/fhir-server/internal/seed"
 )
 
-// MustDB starts a PostgreSQL 16 container, runs schema migrations, and returns
-// a ready pool. The container is terminated when t completes.
+// MustDB starts a PostgreSQL 16 container, creates the schema tables, and
+// returns a ready pool. The container is terminated when t completes.
 func MustDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	ctx := context.Background()
@@ -81,8 +81,8 @@ func MustDB(t *testing.T) *pgxpool.Pool {
 		t.Fatalf("ping: %v", err)
 	}
 
-	if err := db.Migrate(ctx, pool); err != nil {
-		t.Fatalf("migrate: %v", err)
+	if err := db.CreateTables(ctx, pool); err != nil {
+		t.Fatalf("create tables: %v", err)
 	}
 
 	return pool


### PR DESCRIPTION
Addresses a batch of onboarding/setup feedback from trying the server fresh.

## Changes

1. **Readiness check shows nothing** — `curl -s http://localhost:9090/health/ready` prints nothing because the probe returns an empty body, so it looks like the call failed. Switched the README to `curl -sv` so the `< HTTP/1.1 200 OK` status line is visible.

2. **Patient smoke test output unclear** — documented that the `POST` returns the created resource and that piping to `jq .id` prints the server-assigned id, with an example value.

3. **No way to browse the database** — PostgreSQL ships no web UI, so added [Adminer](https://www.adminer.org/) (single lightweight container) to `docker-compose.yml` on port `8080`, with login details in the README.

4. **Local DB setup failed** — `psql -U postgres` fails with `role "postgres" does not exist` on Homebrew/macOS, where the OS user is the superuser. Replaced the single command with per-platform blocks: `psql postgres` (macOS/Homebrew) and `sudo -u postgres psql` (Debian/Ubuntu/RHEL).

5. **Schema creation ran automatically and was mislabeled a "migration"** ⚠️ *behavior change*
   - It is not a migration system — it just applies an additive, idempotent `schema.sql` (`CREATE TABLE IF NOT EXISTS`). Running that on every boot needs the runtime DB role to hold DDL privileges, which it generally should not.
   - Made table creation **opt-in** via `FHIR_CREATE_TABLES` / `database.createTables` (default **off**). When disabled, the server logs that it is skipping creation and expects the tables to already exist.
   - Renamed `db.Migrate` → `db.CreateTables`; logs `"starting database migration"`/`"schema migration complete"` → `"creating database tables"`/`"database tables created"`.
   - `docker-compose.yml` sets `FHIR_CREATE_TABLES=true` so the bundled `fhir` DB owner (which has DDL) still creates tables out of the box — quick-start is unaffected.
   - Updated tests, `config.example.yaml`, `README.md`, and `TESTING.md` to match.

## Verification

- `go build ./...`, `go vet ./...` (incl. `integration` and `conformance` build tags) — clean
- `go test ./internal/config/...` — pass
- `gofmt -l` — clean
- `docker compose config` — valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
