### PR TITLE
fix: log human-readable server timeouts instead of raw nanoseconds

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -124,7 +124,7 @@ func run() error {
 		IdleTimeout:  cfg.IdleTimeout,
 	}
 	slog.Info("HTTP server timeouts configured",
-		"readTimeout", cfg.ReadTimeout, "writeTimeout", cfg.WriteTimeout, "idleTimeout", cfg.IdleTimeout)
+		"readTimeout", cfg.ReadTimeout.String(), "writeTimeout", cfg.WriteTimeout.String(), "idleTimeout", cfg.IdleTimeout.String())
 
 	// Start listening before IGs are loaded so liveness probes pass immediately
 	quit := make(chan os.Signal, 1)


### PR DESCRIPTION
## What

The startup log line `HTTP server timeouts configured` printed each timeout as raw `time.Duration` nanoseconds:

```
"readTimeout":30000000000,"writeTimeout":60000000000,"idleTimeout":120000000000
```

slog renders `time.Duration` as its underlying int64 (nanoseconds), which is hard to read. Logging `.String()` on each value makes it human-readable:

```
"readTimeout":"30s","writeTimeout":"1m0s","idleTimeout":"2m0s"
```

## Why

These timeouts are operator-facing (configurable via `server.{read,write,idle}Timeout` or `SERVER_*_TIMEOUT`). The log is the quickest way to confirm what the server actually resolved at boot, so it should be readable at a glance.

## Scope

One line in `cmd/server/main.go`. No behavior change; build passes (`go build ./cmd/server/`).