### PR TITLE
improve: clearer, more accurate search-param seed/load logging

### DIFF
--- a/internal/searchparam/definitions.go
+++ b/internal/searchparam/definitions.go
@@ -78,7 +78,7 @@ func (r *Registry) RevInclude(targetType string) []string {
 
 // Load reads all definitions from the DB and replaces the current cache.
 func (r *Registry) Load(ctx context.Context, pool *pgxpool.Pool) error {
-	slog.Debug("loading search param definitions from database")
+	slog.Debug("loading search parameter definitions from database into the in-memory registry")
 	rows, err := pool.Query(ctx, `
 		SELECT resource_type, param_name, param_type, fhirpath_expr, is_custom, ig_source,
 		       COALESCE(target_types, ''), COALESCE(components_json, '')
@@ -93,6 +93,7 @@ func (r *Registry) Load(ctx context.Context, pool *pgxpool.Pool) error {
 	byRes := make(map[string][]Definition)
 	byKey := make(map[string]Definition)
 	count := 0
+	var base, fromIG, custom int // by source: base FHIR R4 spec / IG package / user-defined
 
 	for rows.Next() {
 		var d Definition
@@ -109,6 +110,14 @@ func (r *Registry) Load(ctx context.Context, pool *pgxpool.Pool) error {
 		byRes[d.ResourceType] = append(byRes[d.ResourceType], d)
 		byKey[d.ResourceType+"."+d.ParamName] = d
 		count++
+		switch {
+		case d.IsCustom || d.IGSource == "user":
+			custom++
+		case d.IGSource != "":
+			fromIG++
+		default:
+			base++
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate definitions: %w", err)
@@ -134,7 +143,8 @@ func (r *Registry) Load(ctx context.Context, pool *pgxpool.Pool) error {
 	r.revIncl = revIncl
 	r.mu.Unlock()
 
-	slog.Info("loaded search param definitions", "count", count)
+	slog.Info("loaded search parameter definitions into in-memory registry",
+		"total", count, "baseFHIRR4", base, "fromIGs", fromIG, "userDefined", custom)
 	return nil
 }
 

--- a/internal/searchparam/definitions.go
+++ b/internal/searchparam/definitions.go
@@ -78,7 +78,7 @@ func (r *Registry) RevInclude(targetType string) []string {
 
 // Load reads all definitions from the DB and replaces the current cache.
 func (r *Registry) Load(ctx context.Context, pool *pgxpool.Pool) error {
-	slog.Info("loading search param definitions from database")
+	slog.Debug("loading search param definitions from database")
 	rows, err := pool.Query(ctx, `
 		SELECT resource_type, param_name, param_type, fhirpath_expr, is_custom, ig_source,
 		       COALESCE(target_types, ''), COALESCE(components_json, '')

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -38,7 +38,7 @@ var csvFS embed.FS
 // search_param_definitions. Rows that already exist (by resource_type + param_name)
 // are silently skipped so custom parameters are never overwritten.
 func SeedSearchParams(ctx context.Context, pool *pgxpool.Pool) error {
-	slog.Debug("starting to seed FHIR R4 search parameters")
+	slog.Debug("seeding base FHIR R4 search parameters from the international (HL7) spec")
 	f, err := csvFS.Open("fhir-r4-search-params.csv")
 	if err != nil {
 		return fmt.Errorf("open embedded csv: %w", err)
@@ -77,6 +77,7 @@ func seedFromReader(ctx context.Context, pool *pgxpool.Pool, r io.Reader) error 
 	defer tx.Rollback(ctx)
 
 	inserted := 0
+	skipped := 0 // already present (ON CONFLICT DO NOTHING) — e.g. on restart or custom override
 	for {
 		row, err := cr.Read()
 		if err == io.EOF {
@@ -110,7 +111,7 @@ func seedFromReader(ctx context.Context, pool *pgxpool.Pool, r io.Reader) error 
 			componentsJSON = strings.TrimSpace(row[colIdx.componentsJSON])
 		}
 
-		_, err = tx.Exec(ctx, `
+		ct, err := tx.Exec(ctx, `
 			INSERT INTO search_param_definitions
 				(resource_type, param_name, param_type, fhirpath_expr, is_custom, target_types, components_json)
 			VALUES ($1, $2, $3, $4, FALSE, $5, $6)
@@ -120,14 +121,19 @@ func seedFromReader(ctx context.Context, pool *pgxpool.Pool, r io.Reader) error 
 		if err != nil {
 			return fmt.Errorf("insert %s.%s: %w", resourceType, paramName, err)
 		}
-		inserted++
+		if ct.RowsAffected() == 1 {
+			inserted++
+		} else {
+			skipped++
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return err
 	}
 
-	slog.Info("seeded search param definitions", "rows", inserted)
+	slog.Info("seeded base FHIR R4 search parameters from the international (HL7) spec",
+		"inserted", inserted, "skipped", skipped, "total", inserted+skipped)
 	return nil
 }
 

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -38,7 +38,7 @@ var csvFS embed.FS
 // search_param_definitions. Rows that already exist (by resource_type + param_name)
 // are silently skipped so custom parameters are never overwritten.
 func SeedSearchParams(ctx context.Context, pool *pgxpool.Pool) error {
-	slog.Info("starting to seed FHIR R4 search parameters")
+	slog.Debug("starting to seed FHIR R4 search parameters")
 	f, err := csvFS.Open("fhir-r4-search-params.csv")
 	if err != nil {
 		return fmt.Errorf("open embedded csv: %w", err)


### PR DESCRIPTION
## Problem

Server startup emitted four INFO lines for one concern, and they were both noisy and vague/inaccurate:

```
"msg":"starting to seed FHIR R4 search parameters"
"msg":"seeded search param definitions","rows":1709
"msg":"loading search param definitions from database"
"msg":"loaded search param definitions","count":1709
```

Issues:
- The two `starting…`/`loading…` announcements add nothing beyond the completion lines that follow.
- They don't say *what* is being loaded — these are the **base FHIR R4 search parameters from the international (HL7) spec**.
- `rows` was misleading: it counted every CSV row *processed*, not rows actually inserted. Because seeding is `ON CONFLICT DO NOTHING`, a restart against a populated DB still reported `rows:1709` despite inserting nothing.
- The load `count` lumped base + IG + user-defined params together with no breakdown.

## Change

1. Demote the two announcement lines to `Debug` (visible at log level `debug`).
2. Reword the summaries to state they concern the base FHIR R4 / international spec params and the in-memory registry.
3. Seed: track `RowsAffected()` and report `inserted` / `skipped` / `total` truthfully.
4. Load: tally definitions by source and report `baseFHIRR4` / `fromIGs` / `userDefined` alongside `total`.

### After (default INFO level)

First boot (empty DB):
```
"msg":"seeded base FHIR R4 search parameters from the international (HL7) spec","inserted":1709,"skipped":0,"total":1709
"msg":"loaded search parameter definitions into in-memory registry","total":1709,"baseFHIRR4":1709,"fromIGs":0,"userDefined":0
```

Restart (already seeded, with some IG params):
```
"msg":"seeded base FHIR R4 search parameters from the international (HL7) spec","inserted":0,"skipped":1709,"total":1709
"msg":"loaded search parameter definitions into in-memory registry","total":1724,"baseFHIRR4":1709,"fromIGs":15,"userDefined":0
```

## Scope

- `internal/seed/seed.go`
- `internal/searchparam/definitions.go`

`go build ./...`, `go vet`, and `go test ./internal/searchparam/` all pass. No behavior change beyond logging + accurate counters.