### PR TITLE
docs: make IG packages opt-in in example config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,9 +36,13 @@ database:
   # name: fhirdb
 
 ig:
-  # Implementation guides to load at startup.
-  packages:
-    - hl7.fhir.us.core@6.1.0
+  # Implementation guides to load at startup. None are loaded by default —
+  # the server runs as a plain base FHIR R4 store until you opt in here.
+  # Loading an IG fetches its package from registryUrl on first boot and
+  # enables that guide's search parameters and profile validation.
+  # Uncomment to load, e.g. US Core:
+  packages: []
+    # - hl7.fhir.us.core@6.1.0
     # - hl7.fhir.us.carin-bb@2.0.0
   registryUrl: https://packages.fhir.org
   forceReload: false


### PR DESCRIPTION
## Problem

`config.example.yaml` shipped with an IG **active**, unlike every other key in the file:

```yaml
ig:
  packages:
    - hl7.fhir.us.core@6.1.0      # uncommented = actually loaded
```

Every other setting in the example is commented out and merely *documents its default*. This one wasn't, so the documented workflow (copy `config.example.yaml` → `config.yaml`) silently diverged from the real default (no IGs loaded). Copying it would:

- trigger a network fetch from `packages.fhir.org` on first boot (and a delay/failure if offline),
- enable US Core **profile validation** on writes (changing accept/reject behavior),
- populate `ig_packages` — surprising for anyone expecting a plain base FHIR R4 server.

## Change

Set `packages: []` (the true default) and demote US Core to a commented example, with a short note that IGs are opt-in and what loading one does:

```yaml
ig:
  # Implementation guides to load at startup. None are loaded by default —
  # the server runs as a plain base FHIR R4 store until you opt in here.
  # Loading an IG fetches its package from registryUrl on first boot and
  # enables that guide's search parameters and profile validation.
  # Uncomment to load, e.g. US Core:
  packages: []
    # - hl7.fhir.us.core@6.1.0
    # - hl7.fhir.us.carin-bb@2.0.0
```

## Verification

Loaded the edited file through the server's own `config.LoadFromPath` — parses cleanly with `IGPackages` empty (len 0), matching the default. Docs-only change; no code or behavior change.