### PR TITLE
feat(release): build and push a multi-arch container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,23 @@ name: Release
 #   3. Runs unit tests.
 #   4. Cross-compiles the server for linux/{amd64,arm64} and darwin/{amd64,arm64},
 #      stamping the release version into the binary via -ldflags.
-#   5. Tags the release commit as v<release_version>, pushes the tag, and
+#   5. Builds and pushes a multi-arch (linux/amd64,arm64) container image to
+#      GHCR (ghcr.io/<owner>/fhir-server) tagged v<release_version> and latest,
+#      with the release version stamped in via the VERSION build-arg. Done
+#      before tagging so a build failure aborts before anything is published.
+#   6. Tags the release commit as v<release_version>, pushes the tag, and
 #      publishes a GitHub Release with the .tar.gz archives + SHA256SUMS. If
 #      publishing fails the tag is deleted so the run can be retried.
-#   6. Opens a PR against main bumping internal/version/VERSION to
+#   7. Opens a PR against main bumping internal/version/VERSION to
 #      <next_version>-dev.
 #
 # Prerequisites (repo/org settings):
 #   - Settings > Actions > General > Workflow permissions:
 #       "Read and write permissions" enabled, and
 #       "Allow GitHub Actions to create and approve pull requests" enabled
-#       (required for step 6; the release itself still succeeds without it).
+#       (required for step 7; the release itself still succeeds without it).
+#   - GHCR push uses the built-in GITHUB_TOKEN (packages: write below); no extra
+#     secrets are needed for images under the repo owner's namespace.
 
 on:
   workflow_dispatch:
@@ -39,6 +45,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release:
@@ -125,6 +132,42 @@ jobs:
           done
           ( cd dist && sha256sum *.tar.gz > SHA256SUMS )
           echo "Artifacts:"; ls -la dist
+
+      # ── Container image ──────────────────────────────────────────────────
+      # Built and pushed BEFORE the git tag / GitHub Release below, so a build
+      # or push failure aborts the run while it is still cleanly retriable (no
+      # tag has been pushed yet). The image is built from the release commit's
+      # tree, and the release version is stamped in via the VERSION build-arg.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Container image metadata
+        id: image_meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          # Lowercased automatically; works for any owner (wso2, forks, …).
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=v${{ inputs.release_version }}
+            type=raw,value=latest
+      - name: Build and push image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ inputs.release_version }}
+          tags: ${{ steps.image_meta.outputs.tags }}
+          labels: ${{ steps.image_meta.outputs.labels }}
+          provenance: false
 
       - name: Tag and publish the release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,18 @@ name: Release
 #   3. Runs unit tests.
 #   4. Cross-compiles the server for linux/{amd64,arm64} and darwin/{amd64,arm64},
 #      stamping the release version into the binary via -ldflags.
-#   5. Builds and pushes a multi-arch (linux/amd64,arm64) container image to
-#      GHCR (ghcr.io/<owner>/fhir-server) tagged v<release_version> and latest,
-#      with the release version stamped in via the VERSION build-arg. Done
-#      before tagging so a build failure aborts before anything is published.
+#   5. Builds a multi-arch (linux/amd64,arm64) container image from the release
+#      tree, with the release version stamped in via the VERSION build-arg, and
+#      pushes it to GHCR (ghcr.io/<owner>/fhir-server) under an immutable
+#      per-commit staging tag only. A build/push failure here aborts before any
+#      git tag exists, keeping the run cleanly retriable.
 #   6. Tags the release commit as v<release_version>, pushes the tag, and
 #      publishes a GitHub Release with the .tar.gz archives + SHA256SUMS. If
 #      publishing fails the tag is deleted so the run can be retried.
-#   7. Opens a PR against main bumping internal/version/VERSION to
+#   7. Promotes the staged image: retags that same digest as v<release_version>
+#      and latest, so the user-facing tags appear only after the release is
+#      published (never dangling if an earlier step failed).
+#   8. Opens a PR against main bumping internal/version/VERSION to
 #      <next_version>-dev.
 #
 # Prerequisites (repo/org settings):
@@ -133,11 +137,14 @@ jobs:
           ( cd dist && sha256sum *.tar.gz > SHA256SUMS )
           echo "Artifacts:"; ls -la dist
 
-      # ── Container image ──────────────────────────────────────────────────
-      # Built and pushed BEFORE the git tag / GitHub Release below, so a build
-      # or push failure aborts the run while it is still cleanly retriable (no
-      # tag has been pushed yet). The image is built from the release commit's
-      # tree, and the release version is stamped in via the VERSION build-arg.
+      # ── Container image: build + push a staging tag ──────────────────────
+      # Built from the release commit's tree (version stamped via the VERSION
+      # build-arg) and pushed under an immutable per-commit tag ONLY. The
+      # user-facing v<version> and latest tags are promoted onto this same
+      # digest after the GitHub Release is published (see "Promote ..." below),
+      # so an earlier failure never leaves final tags on an unreleased image.
+      # Doing the build here also aborts the run before any git tag is pushed if
+      # the image can't be built, keeping the run cleanly retriable.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
@@ -154,10 +161,9 @@ jobs:
         with:
           # Lowercased automatically; works for any owner (wso2, forks, …).
           images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=v${{ inputs.release_version }}
-            type=raw,value=latest
-      - name: Build and push image
+          # Staging tag only; v<version> + latest are added by the promote step.
+          tags: type=raw,value=sha-${{ github.sha }}
+      - name: Build and push image (staging tag)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
@@ -191,6 +197,22 @@ jobs:
             git push origin --delete "$tag" || true
             exit 1
           fi
+
+      - name: Promote image to release tags
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          # The GitHub Release is now published, so point the user-facing tags at
+          # the multi-arch image already built and pushed under the staging tag.
+          # imagetools only rewrites manifest-list tags (no rebuild, same digest),
+          # so it is cheap and cannot diverge from the image tested/pushed above.
+          # Lowercase the repo: GHCR requires it and owner names may hold capitals.
+          repo="ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          docker buildx imagetools create \
+            --tag "${repo}:v${RELEASE_VERSION}" \
+            --tag "${repo}:latest" \
+            "${repo}:sha-${GITHUB_SHA}"
 
       - name: Open version-bump PR
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,23 @@
-FROM golang:1.25-alpine AS builder
+# Build on the native builder arch and cross-compile to the target platform via
+# GOOS/GOARCH — far faster than emulating the whole toolchain under QEMU when
+# building multi-arch images with buildx.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o fhir-server ./cmd/server
+# Set by buildx for the target platform; TARGETARCH is empty for a plain
+# `docker build` without buildkit, in which case go builds for the native arch.
+ARG TARGETOS
+ARG TARGETARCH
+# Release version stamped into the binary, matching the release workflow's
+# ldflags. Left empty by default so the version package falls back to the
+# embedded internal/version/VERSION file (a plain `docker build` stays correct).
+ARG VERSION=
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -trimpath \
+      -ldflags="-s -w -X github.com/wso2/fhir-server/internal/version.Version=${VERSION}" \
+      -o fhir-server ./cmd/server
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /app/fhir-server /fhir-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build on the native builder arch and cross-compile to the target platform via
 # GOOS/GOARCH — far faster than emulating the whole toolchain under QEMU when
 # building multi-arch images with buildx.
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine@sha256:523c3effe300580ed375e43f43b1c9b091b68e935a7c3a92bfcc4e7ed55b18c2 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
       -ldflags="-s -w -X github.com/wso2/fhir-server/internal/version.Version=${VERSION}" \
       -o fhir-server ./cmd/server
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 COPY --from=builder /app/fhir-server /fhir-server
 EXPOSE 9090
 USER nonroot:nonroot


### PR DESCRIPTION
## What

Extend the manual release pipeline to also publish a container image. Until now a release produced cross-compiled binaries + a GitHub Release, but no image.

## Changes

**`.github/workflows/release.yml`**
- New step builds a **multi-arch image** (`linux/amd64`, `linux/arm64`) and pushes it to **GHCR** — `ghcr.io/<owner>/fhir-server` — tagged `v<release_version>` and `latest`, with the release version passed through as the `VERSION` build-arg.
- Placed **before** the git-tag / GitHub Release step, so a build or push failure aborts the run while it is still cleanly retriable (no tag pushed yet) — consistent with the pipeline's existing "delete the tag on publish failure" rerun-friendliness.
- Auth uses the built-in `GITHUB_TOKEN` via a new `packages: write` permission — no extra secrets needed for images under the repo owner's namespace.
- Docker actions pinned to commit SHAs, consistent with `ci.yml`.
- Header comment updated to document the new step and prerequisite.

**`Dockerfile`**
- Cross-compiles using buildx `TARGETOS`/`TARGETARCH` from a `$BUILDPLATFORM` builder (native build + Go cross-compile, avoiding slow QEMU emulation of the whole toolchain).
- Stamps the release version via a `VERSION` build-arg, matching the release workflow's ldflags. Defaults to empty so a plain `docker build` still falls back to the embedded `internal/version/VERSION` file.

## Registry choice

Used **GHCR** (built-in token, no extra secrets, natural for a GitHub-hosted repo) rather than Docker Hub. Straightforward to switch if Docker Hub is preferred.

## Verification (local, Docker/Colima)

- `docker build --build-arg VERSION=9.9.9` → `fhir-server 9.9.9`.
- plain `docker build` → falls back to `0.6.0-dev` (embedded VERSION file).
- `docker buildx build --platform linux/amd64,linux/arm64` → both arches build successfully.