### PR TITLE
perf(search): make the quantity _source index index-only

### DIFF
--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -199,9 +199,12 @@ CREATE TABLE IF NOT EXISTS sp_quantity (
 -- Raw value range search (same system+code, no unit conversion needed).
 CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (tenant_id, resource_type, param_name, value_low, value_high, system, code);
 -- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
--- deletes; param_name narrows the probe to the parameter. (Restored to its pre-v5
--- form — the diet dropped param_name here too. See the schema_version v8 note.)
-CREATE INDEX IF NOT EXISTS idx_sp_qty_source    ON sp_quantity (tenant_id, resource_id, resource_type, param_name);
+-- deletes. buildQuantityExists filters on value_low/value_high plus optional
+-- system/code, so those trail param_name to keep the probe index-only — matching
+-- the date/number _source indexes. (The pre-v5 form was (resource_id,
+-- resource_type, param_name) with no value columns; widened here for index-only
+-- parity. See the schema_version v8 note.)
+CREATE INDEX IF NOT EXISTS idx_sp_qty_source    ON sp_quantity (tenant_id, resource_id, resource_type, param_name, value_low, value_high, system, code);
 -- Canonical search (cross-unit comparison via UCUM normalisation).
 CREATE INDEX IF NOT EXISTS idx_sp_qty_canonical ON sp_quantity (tenant_id, resource_type, param_name, canonical_value, canonical_units)
     WHERE canonical_value IS NOT NULL;


### PR DESCRIPTION
Follow-up to #16 (already merged), addressing the remaining CodeRabbit finding on that PR that wasn't included before the merge.

## Problem

#16 restored `idx_sp_qty_source` to its pre-v5 form `(tenant_id, resource_id, resource_type, param_name)`. But `buildQuantityExists` (`internal/store/search.go`) filters `sp_quantity` on `value_low`/`value_high` and optional `system`/`code`. Without those columns in the index, the per-resource `EXISTS` probe for quantity searches still falls back to heap access — unlike the `date`/`number` `_source` indexes, which already carry their value columns and resolve index-only.

## Fix

Append `value_low, value_high, system, code` to `idx_sp_qty_source`:

```sql
CREATE INDEX IF NOT EXISTS idx_sp_qty_source ON sp_quantity
  (tenant_id, resource_id, resource_type, param_name, value_low, value_high, system, code);
```

Now the quantity `EXISTS` probe is index-only, consistent with date/number.

## Existing databases

`CREATE INDEX IF NOT EXISTS` won't alter an index that already exists, so existing DBs must DROP+recreate `idx_sp_qty_source` (per the `schema_version` v8 note in `schema.sql`):

```sql
DROP  INDEX CONCURRENTLY IF EXISTS idx_sp_qty_source;
CREATE INDEX CONCURRENTLY idx_sp_qty_source ON sp_quantity
  (tenant_id, resource_id, resource_type, param_name, value_low, value_high, system, code);
```

## Verification

- `go build ./...` — clean.
- Integration tests against Postgres (testcontainers): `internal/db` ✅, `internal/store` ✅ (schema applies; search-by-param incl. quantity).