### PR TITLE
perf(search): flatten composite param EXISTS to avoid full-table scan

### DIFF
--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -413,8 +413,9 @@ func (b *queryBuilder) applyHas(modifier, value string) {
 	))
 }
 
-// buildCompositeExists builds an AND of two component EXISTS subqueries for a
-// composite search param (e.g. code-value-quantity=8480-6$gt110).
+// buildCompositeExists builds a nested-EXISTS predicate for a composite search
+// param (e.g. code-value-quantity=8480-6$gt110): the resource must have both
+// component values (matched independently, correlated on resource_id).
 // The value is split on "$" to get the two component values. Each component's
 // expression maps to a sub-param name in the registry.
 func (b *queryBuilder) buildCompositeExists(def searchparam.Definition, param, value string) (string, bool) {
@@ -439,21 +440,23 @@ func (b *queryBuilder) buildCompositeExists(def searchparam.Definition, param, v
 		return "", false
 	}
 
-	// Build the component EXISTS subqueries directly (not via combinedExists which
-	// wraps them in EXISTS again) so the composite becomes AND(cond1, cond2)
-	// at the same level as other predicates rather than EXISTS(EXISTS AND EXISTS).
+	// Build the two component SELECT bodies. Each is a fully-formed
+	// "SELECT 1 FROM sp_<type> s WHERE s.resource_id = r.fhir_id AND …"
+	// correlated to the outer resource row.
 	cond1, ok1 := b.buildExistsForValue(comp1Name, "", val1)
 	cond2, ok2 := b.buildExistsForValue(comp2Name, "", val2)
 	if !ok1 || !ok2 || cond1 == "" || cond2 == "" {
 		return "", false
 	}
-	// Return a raw AND of the two EXISTS subqueries. The caller in
-	// buildTypedExists → combinedExists will wrap it in EXISTS(...) again,
-	// so we must NOT add EXISTS here — we return the inner content for the
-	// EXISTS wrapper to wrap.
-	// Actually: the caller adds EXISTS around our return value. So we should
-	// return a SELECT that yields 1 when both match. Use INTERSECT:
-	return cond1 + " INTERSECT " + cond2, true
+	// Nest cond2 as a correlated EXISTS inside cond1's WHERE. The caller
+	// (combinedExists) wraps our return value in a single EXISTS(...), producing
+	//   EXISTS (cond1 … AND EXISTS (cond2 …))
+	// Both components are matched independently and correlated only on
+	// resource_id, so the resource matches when it has both component values.
+	// This nested-EXISTS shape is flattenable: Postgres turns it into two
+	// semi-joins driven by the more selective component's sp_* index, rather
+	// than a correlated subplan run once per candidate resource row.
+	return cond1 + " AND EXISTS (" + cond2 + ")", true
 }
 
 // resolveComponentName converts a component expression like "code",


### PR DESCRIPTION
## Problem

Composite search params (e.g. `Observation?code-value-quantity=8480-6$gt110`) were the slowest queries on the perf server — **27–30 s per call**, dominating total DB time (top query alone: 3,463 s across 128 calls).

The query builder emitted the composite predicate as an `EXISTS` wrapping an `INTERSECT`:

```sql
EXISTS (
  SELECT 1 FROM sp_token    s WHERE s.resource_id = r.fhir_id AND ...
  INTERSECT
  SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND ...
)
```

Postgres **cannot flatten an `EXISTS` that wraps a set operation** into a semi-join. The planner fell back to a correlated subplan executed **once per candidate resource row** — i.e. a full scan of the resource type (~2M-row Observation table).

`EXPLAIN` on the perf DB:

```
Index Scan using idx_res_active on resources r  (cost=0.55..7344034.26 rows=379803)
  Filter: EXISTS(SubPlan 1)          <-- run per row
```

## Fix

Both `INTERSECT` branches `SELECT` the constant `1` and correlate **only** on `resource_id`, so the set operation is logically identical to AND-ing the two `EXISTS`. Rewrite as a nested `EXISTS`:

```sql
EXISTS (
  SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND ...
    AND EXISTS (SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND ...)
)
```

This keeps the existing single-`EXISTS` wrapper contract in `combinedExists`, and the planner flattens it into two semi-joins driven by the selective component's `sp_*` index:

```
Nested Loop Semi Join  (cost=6.06..12.32 rows=1)
  -> Index Scan using idx_sp_tok_code on sp_token s
  -> Index Only Scan using idx_sp_qty_source on sp_quantity s_1
```

**Planner cost: 7,344,034 → ~12** (~600,000×) on the live perf DB.

The `sp_*` tables have no element/group column (only `resource_id`), so this is semantically identical to the previous behavior — no change to which resources match.

## Testing

- `go build ./...` + `go vet` clean
- `EXPLAIN` verified against the live perf Postgres (before/after above)
- Integration tests pass (testcontainers): `TestSearch_CompositeParam`, `TestSearch_PreviouslyBlankExpressions`, full `TestSearch` store suite, and conformance `TestConformance_ErrorOutcomes`
