### PR TITLE
perf(search): make Bundle.total opt-in; split COUNT(*) when requested

### DIFF
--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -150,7 +150,7 @@ func TestConformance_History(t *testing.T) {
 func TestConformance_Search_Basics(t *testing.T) {
 	id, idv := createPatient(t, map[string]any{"gender": "female"})
 
-	resp := hreq(t, http.MethodGet, "/Patient?identifier=urn:conformance%7C"+idv, nil)
+	resp := hreq(t, http.MethodGet, "/Patient?identifier=urn:conformance%7C"+idv+"&_total=accurate", nil)
 	wantStatus(t, resp, http.StatusOK)
 	b := jbody(t, resp)
 	if b["resourceType"] != "Bundle" || b["type"] != "searchset" {
@@ -233,7 +233,7 @@ func TestConformance_Search_Chained(t *testing.T) {
 		"managingOrganization": map[string]any{"reference": "Organization/" + orgID},
 	}).Body.Close()
 
-	b := jbody(t, hreq(t, http.MethodGet, "/Patient?organization.name="+orgName, nil))
+	b := jbody(t, hreq(t, http.MethodGet, "/Patient?organization.name="+orgName+"&_total=accurate", nil))
 	if total, _ := b["total"].(float64); total != 1 {
 		t.Errorf("Patient?organization.name=%s: got total %v, want 1", orgName, b["total"])
 	}

--- a/internal/handler/bundle_integration_test.go
+++ b/internal/handler/bundle_integration_test.go
@@ -184,7 +184,7 @@ func TestIntegration_Batch_IndependentEntries(t *testing.T) {
 	}
 
 	// The good Patient persisted despite the sibling failure.
-	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=BatchGood", nil)
+	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=BatchGood&_total=accurate", nil)
 	sbody := iJSON(t, search)
 	if total, _ := sbody["total"].(float64); total != 1 {
 		t.Errorf("want 1 BatchGood Patient, got %v", total)

--- a/internal/handler/conditional_integration_test.go
+++ b/internal/handler/conditional_integration_test.go
@@ -56,7 +56,7 @@ func TestIntegration_ConditionalCreate_IfNoneExist(t *testing.T) {
 	}
 
 	// Exactly one Patient with that identifier should exist.
-	resp = iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?identifier="+sys+"%7Cmrn-1", nil)
+	resp = iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?identifier="+sys+"%7Cmrn-1&_total=accurate", nil)
 	bundle := iJSON(t, resp)
 	if total, _ := bundle["total"].(float64); total != 1 {
 		t.Errorf("expected exactly 1 Patient, got %v", bundle["total"])

--- a/internal/handler/handler_integration_test.go
+++ b/internal/handler/handler_integration_test.go
@@ -347,7 +347,7 @@ func TestIntegration_Search_String(t *testing.T) {
 		"name":         []any{map[string]any{"family": "Dragonborn", "use": "official"}},
 	})
 
-	resp := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=dragon", nil)
+	resp := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=dragon&_total=accurate", nil)
 	bundle := iJSON(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("search: want 200, got %d", resp.StatusCode)
@@ -364,7 +364,7 @@ func TestIntegration_Search_Token(t *testing.T) {
 	iCreate(t, srv, "Patient", map[string]any{"resourceType": "Patient", "gender": "female"})
 	iCreate(t, srv, "Patient", map[string]any{"resourceType": "Patient", "gender": "male"})
 
-	resp := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?gender=female", nil)
+	resp := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?gender=female&_total=accurate", nil)
 	bundle := iJSON(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("search: want 200, got %d", resp.StatusCode)
@@ -390,7 +390,7 @@ func TestIntegration_SearchPost(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodPost,
 		srv.URL+"/fhir/r4/Patient/_search",
-		strings.NewReader("gender=male"),
+		strings.NewReader("gender=male&_total=accurate"),
 	)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := srv.Client().Do(req)
@@ -416,23 +416,40 @@ func TestIntegration_Search_Pagination_Links(t *testing.T) {
 		iCreate(t, srv, "Patient", map[string]any{"resourceType": "Patient"})
 	}
 
-	// Page 1 with _count=2 — expect self/first/last/next but no previous
+	// Default (no _total): the count is skipped, so there is no "last" link and
+	// no bundle total, but a full page still yields a "next" link.
 	resp := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?_page=1&_count=2", nil)
 	bundle := iJSON(t, resp)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 	rels := linkRels(bundle)
-	for _, rel := range []string{"self", "first", "last", "next"} {
+	for _, rel := range []string{"self", "first", "next"} {
 		if rels[rel] == "" {
-			t.Errorf("page 1: expected link %q to be present; links=%v", rel, rels)
+			t.Errorf("page 1 (default): expected link %q to be present; links=%v", rel, rels)
 		}
+	}
+	if rels["last"] != "" {
+		t.Errorf("page 1 (default, no _total): should have no last link, got %q", rels["last"])
+	}
+	if _, ok := bundle["total"]; ok {
+		t.Errorf("page 1 (default, no _total): should omit bundle total, got %v", bundle["total"])
 	}
 	if rels["previous"] != "" {
 		t.Errorf("page 1 should have no previous link, got %q", rels["previous"])
 	}
 
-	// Page 2 — expect both next and previous
+	// With _total=accurate: the count is computed, so a "last" link appears.
+	resp = iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?_page=1&_count=2&_total=accurate", nil)
+	bundle = iJSON(t, resp)
+	rels = linkRels(bundle)
+	for _, rel := range []string{"self", "first", "next", "last"} {
+		if rels[rel] == "" {
+			t.Errorf("page 1 (_total=accurate): expected link %q to be present; links=%v", rel, rels)
+		}
+	}
+
+	// Page 2 (default) — expect both next (full page) and previous
 	resp = iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?_page=2&_count=2", nil)
 	bundle = iJSON(t, resp)
 	rels = linkRels(bundle)

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -206,6 +206,19 @@ func firstVal(params map[string][]string, key string) string {
 	return ""
 }
 
+// totalMode resolves the search _total mode. When the client does not specify
+// _total, the server defaults to "none": it does NOT compute Bundle.total. An
+// accurate total is a COUNT(*) over the full match set, which is O(matches) and
+// impractical for broad searches, so like most production FHIR servers we make
+// it opt-in. Clients that need the count request _total=accurate (or estimate),
+// which routes to the counted path in the store.
+func totalMode(params map[string][]string) string {
+	if v := firstVal(params, "_total"); v != "" {
+		return v
+	}
+	return "none"
+}
+
 // parseIfMatchVersion extracts the integer version from an ETag like W/"3".
 // Returns (version, true) on success, (0, false) if the header is malformed.
 func parseIfMatchVersion(header string) (int, bool) {
@@ -269,7 +282,7 @@ func (h *fhirHandler) search(w http.ResponseWriter, r *http.Request) {
 		Params:       params,
 		Page:         page,
 		PageSize:     pageSize,
-		Total:        firstVal(params, "_total"),
+		Total:        totalMode(params),
 		CountOnly:    summary == "count",
 	})
 	if err != nil {
@@ -313,7 +326,7 @@ func (h *fhirHandler) searchPost(w http.ResponseWriter, r *http.Request) {
 		Params:       params,
 		Page:         page,
 		PageSize:     pageSize,
-		Total:        firstVal(params, "_total"),
+		Total:        totalMode(params),
 		CountOnly:    summary == "count",
 	})
 	if err != nil {
@@ -362,8 +375,9 @@ func (h *fhirHandler) buildBundle(baseURL, rt string, result store.SearchResult,
 		map[string]any{"relation": "self", "url": base + "?" + pageQuery(params, page, pageSize)},
 		map[string]any{"relation": "first", "url": base + "?" + pageQuery(params, 1, pageSize)},
 	}
-	// result.Total < 0 means the count was skipped (_total=none): we can't
-	// compute the last page or a count-based next link.
+	// result.Total < 0 means the count was skipped (the default _total=none):
+	// without a count we can't compute the last page or a count-based next link,
+	// so we fall back to a full-page heuristic for "next" and omit "last".
 	if result.Total >= 0 {
 		lastPage := result.Total / pageSize
 		if result.Total%pageSize != 0 {
@@ -379,6 +393,13 @@ func (h *fhirHandler) buildBundle(baseURL, rt string, result store.SearchResult,
 				"url":      base + "?" + pageQuery(params, page+1, pageSize),
 			})
 		}
+	} else if len(result.Entries) == pageSize {
+		// A full page of matches without a total: there may be more results, so
+		// offer "next". A subsequent short/empty page ends the chain (no "next").
+		links = append(links, map[string]any{
+			"relation": "next",
+			"url":      base + "?" + pageQuery(params, page+1, pageSize),
+		})
 	}
 	if page > 1 {
 		links = append(links, map[string]any{

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -129,7 +129,9 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 	total := -1
 	var entries []map[string]any
 	if sp.Total == "none" {
-		// _total=none: skip the count entirely, just fetch rows.
+		// _total=none: skip the count entirely, just fetch rows. This is the
+		// default for API search requests (see handler.totalMode); an accurate
+		// count is opt-in because it scans the whole match set.
 		var err error
 		entries, err = b.fetch(ctx, c, sp.PageSize, offset)
 		if err != nil {
@@ -138,7 +140,9 @@ func (s *Store) Search(ctx context.Context, sp SearchParams) (SearchResult, erro
 		}
 		slog.Debug("search completed", "resourceType", sp.ResourceType, "returned", len(entries))
 	} else {
-		// Default: fetch rows and total in a single query via COUNT(*) OVER().
+		// _total=accurate|estimate (and internal callers that leave Total unset):
+		// compute the exact count. fetchWithCount runs a dedicated COUNT(*) plus
+		// an early-terminating page fetch.
 		var err error
 		total, entries, err = b.fetchWithCount(ctx, c, sp.PageSize, offset)
 		if err != nil {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1383,49 +1383,32 @@ func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset in
 	return entries, rows.Err()
 }
 
-// fetchWithCount fetches matching rows and the total result count in a single
-// round-trip using COUNT(*) OVER() as a window function. COUNT(*) OVER() is
-// evaluated before LIMIT, so it returns the full match count regardless of
-// page size. This saves a round-trip compared to the previous pattern of a
-// separate SELECT COUNT(*) followed by a paginated SELECT; when ORDER BY
-// requires a sort (no covering index), it also halves the scan work.
+// fetchWithCount returns the page of matching rows plus the exact total match
+// count, using two queries: a dedicated COUNT(*) and a paginated fetch.
+//
+// The count runs first, before fetch() appends the ORDER BY / LIMIT / OFFSET
+// parameters to b.args, so the count query binds only the WHERE arguments.
+//
+// This deliberately avoids COUNT(*) OVER() in the fetch. A window count is
+// evaluated over the entire result set before LIMIT applies, which forces the
+// planner to materialize and sort every matching row even though only `limit`
+// are returned. For a broad predicate (one matching a large fraction of the
+// table) that is the dominant cost: the page fetch alone, ordered by an indexed
+// column, can stop after `limit` rows via the ordered index, whereas the window
+// count cannot early-terminate. Splitting the two lets the fetch early-terminate
+// and keeps the count to a bare aggregate that need not carry resource_json or
+// sort — measured ~5x faster on broad searches against the perf dataset, with
+// the exact total preserved.
 func (b *queryBuilder) fetchWithCount(ctx context.Context, pool querier, limit, offset int) (int, []map[string]any, error) {
-	orderBy := b.orderByClause()
-	limitP := b.next(limit)
-	offsetP := b.next(offset)
-	q := fmt.Sprintf(`
-		SELECT r.resource_json, r.version_id, r.last_updated, COUNT(*) OVER() AS total_count
-		FROM resources r
-		WHERE %s
-		ORDER BY %s
-		LIMIT %s OFFSET %s`,
-		b.where.String(), orderBy, limitP, offsetP,
-	)
-
-	rows, err := pool.Query(ctx, q, b.args...)
+	total, err := b.count(ctx, pool)
 	if err != nil {
 		return 0, nil, err
 	}
-	defer rows.Close()
-
-	var total int
-	var entries []map[string]any
-	for rows.Next() {
-		var raw []byte
-		var versionID int
-		var lastUpdated time.Time
-		var totalCount int
-		if err := rows.Scan(&raw, &versionID, &lastUpdated, &totalCount); err != nil {
-			return 0, nil, err
-		}
-		total = totalCount // same value on every row; unconditional assignment is clearer
-		m, err := unmarshalWithMeta(raw, versionID, lastUpdated)
-		if err != nil {
-			return 0, nil, err
-		}
-		entries = append(entries, m)
+	entries, err := b.fetch(ctx, pool, limit, offset)
+	if err != nil {
+		return 0, nil, err
 	}
-	return total, entries, rows.Err()
+	return total, entries, nil
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #21. After composite `EXISTS` flattening landed, the remaining slow searches were dominated by **`Bundle.total`** — computing an exact total is a `COUNT(*)` over the whole match set (O(matches)), which is impractical for broad searches. This PR makes the total **opt-in** and makes the counted path cheaper when it *is* requested.

## 1. `Bundle.total` is now opt-in (default `_total=none`)

No mainstream FHIR server computes an accurate total unconditionally. The server now defaults to **not** emitting `total`; clients that need it request `_total=accurate` (or `estimate`).

- `handler.totalMode()`: absent `_total` → `"none"`; explicit values pass through. Applied to GET and POST search.
- The **store default is unchanged**, so internal callers that genuinely need a count — conditional create/update (`If-None-Exist`), `_summary=count` — still get exact counts. Only the API's default for external clients changes.
- **Pagination without a total:** the `next` link is now derived from a full page of matches (`len(entries) == pageSize`) instead of from the count, so clients can still page through results. `last` is emitted only when the total is known (`_total=accurate`).

Effect on the benchmark's broad searches: they take the count-free fetch path — the ~1.2 ms early-terminating page fetch instead of a multi-hundred-ms/second count.

## 2. When a total *is* requested, compute it via a split query

`fetchWithCount` no longer uses `COUNT(*) OVER()` (which forces the planner to materialize and sort every matching row before `LIMIT`). It runs a dedicated `COUNT(*)` plus the existing paginated fetch (count first, before ORDER BY/LIMIT args are appended). The fetch early-terminates on the `last_updated` index; the count is a bare aggregate. Both run on the same tenant-scoped connection, so RLS isolation and total accuracy are preserved.

`EXPLAIN ANALYZE`, `value-quantity` range matching ~460k of 771k Observations: **2,387 ms → 418 ms + 1.2 ms (~5×)**.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean
- `EXPLAIN ANALYZE` verified on the live perf DB (numbers above)
- Integration + conformance suites pass (testcontainers): full `TestSearch` store suite, `TestTenantIsolation`, the handler suite, and the conformance suite. Tests that assert an exact count now opt into `_total=accurate`; the pagination test covers both the default (`next`, no `last`, no `total`) and the accurate path (`last` present).
