### PR TITLE
perf(search): trust the planner — feed it stats, drop id-first branching

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -34,6 +34,21 @@ func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("parse dsn: %w", err)
 	}
 
+	// Force per-value (custom) plans instead of cached generic plans. Search
+	// plan quality depends heavily on the specific bound value's selectivity:
+	// the planner must see the literal to choose between an ordered early-exit
+	// scan (dense predicate) and driving from the sp_* value index (sparse or
+	// empty predicate). Under a generic plan it cannot tell them apart — e.g. a
+	// dense token like category=laboratory (~70% of rows) degrades to a
+	// HashAggregate over the whole match set (~2.9s), where a custom plan sees
+	// the value's MCV stats and takes the ordered scan (~6ms). Planning cost per
+	// query is negligible next to search execution. Set as a startup RuntimeParam
+	// so every pooled connection uses it.
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["plan_cache_mode"] = "force_custom_plan"
+
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("open pool: %w", err)

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -168,7 +168,10 @@ CREATE TABLE IF NOT EXISTS sp_number (
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_sp_num_range  ON sp_number (tenant_id, resource_type, param_name, value_low, value_high);
+-- INCLUDE (resource_id) makes the range scan covering: when the planner drives a
+-- sparse/empty numeric search from this value index it resolves the matching
+-- fhir_id index-only, without a per-match heap fetch.
+CREATE INDEX IF NOT EXISTS idx_sp_num_range  ON sp_number (tenant_id, resource_type, param_name, value_low, value_high) INCLUDE (resource_id);
 -- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
 -- deletes; param_name + range columns keep the probe index-only. (Restored from
 -- the v5 diet's (resource_id, resource_type) — see the schema_version v8 note.)
@@ -197,7 +200,9 @@ CREATE TABLE IF NOT EXISTS sp_quantity (
 );
 
 -- Raw value range search (same system+code, no unit conversion needed).
-CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (tenant_id, resource_type, param_name, value_low, value_high, system, code);
+-- INCLUDE (resource_id) makes the range scan covering so a sparse/empty numeric
+-- search driven from this value index resolves the fhir_id index-only.
+CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (tenant_id, resource_type, param_name, value_low, value_high, system, code) INCLUDE (resource_id);
 -- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
 -- deletes. buildQuantityExists filters on value_low/value_high plus optional
 -- system/code, so those trail param_name to keep the probe index-only — matching
@@ -391,6 +396,19 @@ ALTER TABLE sp_token     ALTER COLUMN param_name    SET STATISTICS 1000;
 ALTER TABLE sp_reference ALTER COLUMN target_id     SET STATISTICS 1000;
 ALTER TABLE sp_reference ALTER COLUMN param_name    SET STATISTICS 1000;
 
+-- Multivariate statistics: the per-column targets above still let the planner
+-- assume resource_type / param_name / code are independent, so it badly
+-- under-estimates a common (resource_type, param_name, code) combination — e.g.
+-- Observation category=vital-signs (~20% of Observations) was estimated at <2%.
+-- That misestimate made it materialize + sort the entire match set (135k rows,
+-- one resources lookup each) instead of the abort-early ordered scan that stops
+-- at the first page: ~966ms vs ~15ms on the perf dataset. MCV/dependencies over
+-- the correlated columns correct the estimate so the planner picks the ordered
+-- early-exit scan for dense codes and drives from the sp_* value index for
+-- sparse ones. Populated by ANALYZE (autoanalyze covers this after bulk import).
+CREATE STATISTICS IF NOT EXISTS stx_sp_token_rt_param_code (dependencies, ndistinct, mcv)
+    ON resource_type, param_name, code FROM sp_token;
+
 -- ─── Autovacuum tuning for high-churn tables ─────────────────────────────────
 -- Default autovacuum_vacuum_scale_factor=0.20 means PostgreSQL waits until 20%
 -- of a table is dead before cleaning up. On tables with millions of rows that
@@ -492,3 +510,37 @@ INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;
 --       ON sp_string (tenant_id, resource_id, resource_type, param_name, value_lower);
 -- (repeat for tok/date/num/qty/uri/ref with the column lists above).
 INSERT INTO schema_version (version) VALUES (8) ON CONFLICT DO NOTHING;
+
+-- v9: mark numeric comparison operators LEAKPROOF so quantity/number range and
+-- equality predicates push into the sp_quantity/sp_number indexes under RLS.
+--
+-- With Row-Level Security the sp_* tables are security barriers: a user WHERE
+-- qual is evaluated *inside* the index scan (as an index cond) only if its
+-- operator is LEAKPROOF; otherwise it is held back and applied as a post-filter
+-- above the barrier. PostgreSQL ships text and date/timestamptz comparisons
+-- LEAKPROOF, but NOT the numeric ones. So `value_low > $1` on sp_quantity
+-- (numeric(20,6)) could not use the (tenant_id, resource_type, param_name,
+-- value_low, …) index bound — every quantity/number search scanned the entire
+-- (tenant, type, param) partition and filtered value_low in memory (~50ms/query
+-- on the perf dataset, and far worse under concurrency where it spawned parallel
+-- seq scans). numeric comparison operators are pure arithmetic and do not leak
+-- argument values via errors or side channels, so marking them LEAKPROOF is safe.
+--
+-- Requires superuser: only a superuser may set LEAKPROOF. Wrapped so a non-super
+-- DDL role (or managed Postgres with no superuser, e.g. Azure Flexible Server)
+-- still applies the rest of the schema — the optimization is skipped with a
+-- notice and those searches fall back to the correct, slower post-filter path.
+DO $leakproof$
+BEGIN
+    ALTER FUNCTION numeric_eq(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_gt(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_ge(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_lt(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_le(numeric, numeric) LEAKPROOF;
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RAISE NOTICE 'skipping LEAKPROOF on numeric comparison operators (requires superuser); quantity/number range searches under RLS will use a slower post-filter';
+END
+$leakproof$;
+
+INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Problem

Search TPS was low under load. The root cause is **plan choice**, not a missing access path: for a value predicate ordered by recency under `LIMIT`, the planner has to choose between an ordered early-exit scan (great when the predicate is *dense*) and driving from the `sp_*` value index (great when it's *sparse/empty*). Given the right statistics it picks correctly; without them it guesses wrong and either full-scans or materialises + sorts the whole match set.

An earlier approach (#23) worked around this by hardcoding an "id-first" query shape per param type in Go (a `MATERIALIZED` CTE forced for all quantity/number searches). That fixed sparse searches but **regressed dense ones** — e.g. `combo-value-quantity=le140` (matches 88% of rows) materialised 506K rows and top-N sorted them, spilling 28 MB to temp: ~200 ms warm, ~1 s cold/under load. It also reintroduced branching sprawl (`suppressDirectDrive`, `idFirstType`, `directDrive`, …) and a latent duplicate-row bug (the direct-drive shape didn't dedupe `resource_id`).

## Approach

Don't hardcode the path — **give the planner what it needs and let it choose per value**:

- **`force_custom_plan`** (`db.go`) so the planner sees the literal search value. Under a generic/cached plan it cannot tell a sparse code from a dense one.
- **Multivariate statistics** on `sp_token (resource_type, param_name, code)` so correlated codes aren't under-estimated.
- **`LEAKPROOF`** numeric comparison operators so quantity/number range predicates push into the `sp_*` value index under RLS instead of a post-filter.
- **`INCLUDE (resource_id)`** on the numeric value indexes so a sparse/empty search resolves the `fhir_id` index-only.

No application-level plan forcing. The search query builder is unchanged from `main` (the plain resources-driven `EXISTS` … `ORDER BY last_updated LIMIT` shape), which dedupes naturally and lets the planner drive from either side.

## Validation

`EXPLAIN ANALYZE` on the perf dataset (1.66M resources, 1.15M `sp_quantity` rows), of the exact query the store emits:

| Search | Selectivity | Plan chosen | Time |
|---|---|---|---|
| `combo-value-quantity=le140` | dense (88%) | resources-ordered early-exit (idx_res_active), stop after 35 rows | **1.25 ms** |
| `combo-value-quantity=gt900` | sparse (2.3%) | parallel semi-join | 42 ms |
| `combo-value-quantity` > 999999 | empty | driven from `sp_*` value index + HashAggregate | **0.18 ms** |

The empty/sparse case #23 was built to fix is already handled by the planner once these stats exist — for dense it's ~165× faster than the forced id-first plan.

## Notes / follow-ups

- The sparse-*mid* band (~42 ms) uses a parallel semi-join; it's an optimisation candidate (not a correctness cliff) and is deliberately left to the planner here rather than re-forced.
- `force_custom_plan` is currently pool-wide. It's load-bearing for search; a follow-up could scope it to the search path so simple CRUD keeps generic-plan reuse.
- Supersedes #23. Keeps that PR's planner-feeding foundation; drops its id-first machinery and the denormalised `last_updated` columns (only the forced shape used them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)