### PR TITLE
perf(search): early-exit id-first fetch — fast for dense, sparse, and empty

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -34,6 +34,20 @@ func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("parse dsn: %w", err)
 	}
 
+	// Force per-value (custom) plans instead of cached generic plans. Several
+	// search predicates have plan quality that depends heavily on the specific
+	// bound value's selectivity — most notably token equality, where a generic
+	// plan cannot tell a sparse code (id-first resolve) from a dense one (ordered
+	// early-exit). Under a generic plan a dense token like category=laboratory
+	// (~70% of rows) degrades to a HashAggregate over the whole match set (~2.9s);
+	// with a custom plan the planner sees the value's MCV stats and takes the
+	// ordered scan (~6ms). Planning cost per query is negligible next to search
+	// execution. Set as a startup RuntimeParam so every pooled connection uses it.
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["plan_cache_mode"] = "force_custom_plan"
+
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("open pool: %w", err)

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -492,3 +492,37 @@ INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;
 --       ON sp_string (tenant_id, resource_id, resource_type, param_name, value_lower);
 -- (repeat for tok/date/num/qty/uri/ref with the column lists above).
 INSERT INTO schema_version (version) VALUES (8) ON CONFLICT DO NOTHING;
+
+-- v9: mark numeric comparison operators LEAKPROOF so quantity/number range and
+-- equality predicates push into the sp_quantity/sp_number indexes under RLS.
+--
+-- With Row-Level Security the sp_* tables are security barriers: a user WHERE
+-- qual is evaluated *inside* the index scan (as an index cond) only if its
+-- operator is LEAKPROOF; otherwise it is held back and applied as a post-filter
+-- above the barrier. PostgreSQL ships text and date/timestamptz comparisons
+-- LEAKPROOF, but NOT the numeric ones. So `value_low > $1` on sp_quantity
+-- (numeric(20,6)) could not use the (tenant_id, resource_type, param_name,
+-- value_low, …) index bound — every quantity/number search scanned the entire
+-- (tenant, type, param) partition and filtered value_low in memory (~50ms/query
+-- on the perf dataset, and far worse under concurrency where it spawned parallel
+-- seq scans). numeric comparison operators are pure arithmetic and do not leak
+-- argument values via errors or side channels, so marking them LEAKPROOF is safe.
+--
+-- Requires superuser: only a superuser may set LEAKPROOF. Wrapped so a non-super
+-- DDL role (or managed Postgres with no superuser, e.g. Azure Flexible Server)
+-- still applies the rest of the schema — the optimization is skipped with a
+-- notice and those searches fall back to the correct, slower post-filter path.
+DO $leakproof$
+BEGIN
+    ALTER FUNCTION numeric_eq(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_gt(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_ge(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_lt(numeric, numeric) LEAKPROOF;
+    ALTER FUNCTION numeric_le(numeric, numeric) LEAKPROOF;
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RAISE NOTICE 'skipping LEAKPROOF on numeric comparison operators (requires superuser); quantity/number range searches under RLS will use a slower post-filter';
+END
+$leakproof$;
+
+INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -165,10 +165,18 @@ CREATE TABLE IF NOT EXISTS sp_number (
     value         DECIMAL(20,6) NOT NULL,
     value_low     DECIMAL(20,6) NOT NULL,
     value_high    DECIMAL(20,6) NOT NULL,
+    -- Denormalised copy of resources.last_updated, set at index time to the exact
+    -- value written to resources. Lets the id-first fetch sort candidates straight
+    -- from idx_sp_num_range without a per-match resources lookup — see fetchSQL's
+    -- direct-drive shape.
+    last_updated  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS idx_sp_num_range  ON sp_number (tenant_id, resource_type, param_name, value_low, value_high);
+-- INCLUDE (resource_id, last_updated) makes the range scan covering: the id-first
+-- candidate resolve is index-only, yielding the fhir_id to join and the sort key
+-- to order by without touching the heap.
+CREATE INDEX IF NOT EXISTS idx_sp_num_range  ON sp_number (tenant_id, resource_type, param_name, value_low, value_high) INCLUDE (resource_id, last_updated);
 -- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
 -- deletes; param_name + range columns keep the probe index-only. (Restored from
 -- the v5 diet's (resource_id, resource_type) — see the schema_version v8 note.)
@@ -193,11 +201,18 @@ CREATE TABLE IF NOT EXISTS sp_quantity (
     code             VARCHAR(64),
     canonical_value  DECIMAL(20,6),
     canonical_units  VARCHAR(64),
+    -- Denormalised copy of resources.last_updated, set at index time to the exact
+    -- value written to resources. Lets the id-first fetch sort candidates straight
+    -- from idx_sp_qty_raw without a per-match resources lookup — see fetchSQL's
+    -- direct-drive shape.
+    last_updated     TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
 -- Raw value range search (same system+code, no unit conversion needed).
-CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (tenant_id, resource_type, param_name, value_low, value_high, system, code);
+-- INCLUDE (resource_id, last_updated) makes the range scan covering so the
+-- id-first candidate resolve is index-only (fhir_id to join + sort key to order).
+CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (tenant_id, resource_type, param_name, value_low, value_high, system, code) INCLUDE (resource_id, last_updated);
 -- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
 -- deletes. buildQuantityExists filters on value_low/value_high plus optional
 -- system/code, so those trail param_name to keep the probe index-only — matching

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -173,6 +173,13 @@ CREATE TABLE IF NOT EXISTS sp_number (
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
+-- Migration for pre-existing deployments: CREATE TABLE IF NOT EXISTS above does
+-- NOT add last_updated to an already-created sp_number, and the covering /
+-- recency indexes below reference it (idx_sp_num_recent keys on it). ADD COLUMN
+-- IF NOT EXISTS is a no-op on fresh installs and backfills existing rows with the
+-- DEFAULT, so both paths end up with the column before the indexes are built.
+ALTER TABLE sp_number ADD COLUMN IF NOT EXISTS last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
 -- INCLUDE (resource_id, last_updated) makes the range scan covering: the id-first
 -- candidate resolve is index-only, yielding the fhir_id to join and the sort key
 -- to order by without touching the heap.
@@ -208,6 +215,10 @@ CREATE TABLE IF NOT EXISTS sp_quantity (
     last_updated     TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
+
+-- Migration for pre-existing deployments (see the sp_number note above): backfill
+-- last_updated before the covering / recency indexes that reference it are built.
+ALTER TABLE sp_quantity ADD COLUMN IF NOT EXISTS last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 -- Raw value range search (same system+code, no unit conversion needed).
 -- INCLUDE (resource_id, last_updated) makes the range scan covering so the

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -107,6 +107,10 @@ CREATE TABLE IF NOT EXISTS sp_token (
     system        VARCHAR(512),
     code          VARCHAR(191),
     display       VARCHAR(512),
+    -- Denormalised copy of resources.last_updated, set at index time. Lets the
+    -- composite early-exit drive (fetchSQL's composite shape) walk sp_token
+    -- newest-first for a code and stop after one page, without a resources lookup.
+    last_updated  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
@@ -596,3 +600,26 @@ CREATE INDEX IF NOT EXISTS idx_sp_qty_recent ON sp_quantity (tenant_id, resource
 CREATE INDEX IF NOT EXISTS idx_sp_num_recent ON sp_number   (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id);
 
 INSERT INTO schema_version (version) VALUES (10) ON CONFLICT DO NOTHING;
+
+-- v11: recency covering index on sp_token, ordered by last_updated DESC, for the
+-- composite early-exit drive (fetchSQL's composite shape, see search.go).
+--
+-- A composite token+quantity search (e.g. code-value-quantity) drives candidate
+-- resolution from the selective token component, then filters by the quantity
+-- component. Without a recency-ordered token index the drive had to resolve the
+-- whole intersection and top-N sort it — cheap for a selective code, but for a
+-- common code with a loose value bound (e.g. body-weight code + value>80, an
+-- 8k-row intersection) that was a multi-second materialise-and-sort that also
+-- tripped a parallel hash join. Ordering the index by last_updated DESC lets the
+-- drive walk sp_token newest-first for the code, probe the quantity component
+-- per row, and stop after one page. INCLUDE (resource_id, system) keeps the walk
+-- (and an optional system filter) index-only.
+--
+-- Migration for pre-existing deployments (mirrors the sp_number / sp_quantity
+-- v10 note): ADD COLUMN before the recency index that references it. Existing
+-- rows take the migration-time default; the exact resources.last_updated is
+-- written on the next re-index, matching how the numeric tables were populated.
+ALTER TABLE sp_token ADD COLUMN IF NOT EXISTS last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW();
+CREATE INDEX IF NOT EXISTS idx_sp_tok_recent ON sp_token (tenant_id, resource_type, param_name, code, last_updated DESC) INCLUDE (resource_id, system) WHERE code IS NOT NULL;
+
+INSERT INTO schema_version (version) VALUES (11) ON CONFLICT DO NOTHING;

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -554,3 +554,21 @@ END
 $leakproof$;
 
 INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;
+
+-- v10: recency covering indexes on the numeric sp_* tables, ordered by
+-- last_updated DESC, for the early-exit id-first fetch (directDriveSQL).
+--
+-- The value indexes above (idx_sp_qty_raw / idx_sp_num_range) are ordered by
+-- value, so a search sorted by recency had to read the entire match set and
+-- top-N sort it — fine for a sparse predicate, but for a DENSE one (e.g.
+-- value-quantity=le140 matching ~500k rows) that was a multi-hundred-ms
+-- materialise-and-sort. Ordering the index by last_updated DESC lets the
+-- planner walk it newest-first, apply the value predicate from the INCLUDE'd
+-- columns, and stop after one page (~1ms), while a sparse/empty predicate still
+-- uses the value index. The planner chooses between the two per bound value
+-- (force_custom_plan) from the single sp_* table's own statistics — no
+-- application-level plan forcing.
+CREATE INDEX IF NOT EXISTS idx_sp_qty_recent ON sp_quantity (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id, system, code);
+CREATE INDEX IF NOT EXISTS idx_sp_num_recent ON sp_number   (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id);
+
+INSERT INTO schema_version (version) VALUES (10) ON CONFLICT DO NOTHING;

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -430,6 +430,19 @@ ALTER TABLE sp_reference ALTER COLUMN param_name    SET STATISTICS 1000;
 CREATE STATISTICS IF NOT EXISTS stx_sp_token_rt_param_code (dependencies, ndistinct, mcv)
     ON resource_type, param_name, code FROM sp_token;
 
+-- system|code searches (the common token form, e.g.
+-- class=http://terminology.hl7.org/CodeSystem/v3-ActCode|AMB) filter on system
+-- AND code, which are strongly correlated — a code like AMB only ever appears
+-- under its own system. Without system in the stats the planner treats them as
+-- independent and badly UNDER-estimates a dense combination: Encounter class=AMB
+-- (62k rows) was estimated at 593, so it materialised + sorted every match and
+-- joined resources per row (~2.7s) instead of the abort-early ordered scan
+-- (~0.7ms). Adding system to the multivariate stat corrects the estimate so the
+-- planner takes the ordered early-exit for dense system|code tokens and keeps
+-- the id-first materialize for sparse ones. Populated by ANALYZE.
+CREATE STATISTICS IF NOT EXISTS stx_sp_token_rt_param_sys_code (dependencies, ndistinct, mcv)
+    ON resource_type, param_name, system, code FROM sp_token;
+
 -- ─── Autovacuum tuning for high-churn tables ─────────────────────────────────
 -- Default autovacuum_vacuum_scale_factor=0.20 means PostgreSQL waits until 20%
 -- of a table is dead before cleaning up. On tables with millions of rows that

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -406,6 +406,19 @@ ALTER TABLE sp_token     ALTER COLUMN param_name    SET STATISTICS 1000;
 ALTER TABLE sp_reference ALTER COLUMN target_id     SET STATISTICS 1000;
 ALTER TABLE sp_reference ALTER COLUMN param_name    SET STATISTICS 1000;
 
+-- Multivariate statistics: the per-column targets above still let the planner
+-- assume resource_type / param_name / code are independent, so it badly
+-- under-estimates a common (resource_type, param_name, code) combination — e.g.
+-- Observation category=vital-signs (~20% of Observations) was estimated at <2%.
+-- That misestimate made it materialize + sort the entire match set (135k rows,
+-- one resources lookup each) instead of the abort-early ordered scan that stops
+-- at the first page: ~966ms vs ~15ms on the perf dataset. MCV/dependencies over
+-- the correlated columns correct the estimate so the planner picks the ordered
+-- scan for dense codes and the id-first-style materialize for sparse ones.
+-- Populated by ANALYZE (autoanalyze covers this after the bulk import).
+CREATE STATISTICS IF NOT EXISTS stx_sp_token_rt_param_code (dependencies, ndistinct, mcv)
+    ON resource_type, param_name, code FROM sp_token;
+
 -- ─── Autovacuum tuning for high-churn tables ─────────────────────────────────
 -- Default autovacuum_vacuum_scale_factor=0.20 means PostgreSQL waits until 20%
 -- of a table is dead before cleaning up. On tables with millions of rows that

--- a/internal/index/extractor.go
+++ b/internal/index/extractor.go
@@ -411,9 +411,9 @@ func queueNumber(batch *pgx.Batch, rt, rid, param string, vals []any, lastUpdate
 		// last_updated mirrors resources.last_updated so the id-first fetch can
 		// sort candidates from idx_sp_num_range without a resources lookup.
 		batch.Queue(
-			`INSERT INTO sp_number (resource_id, resource_type, param_name, value_low, value_high, last_updated)
-			 VALUES ($1, $2, $3, $4, $5, $6)`,
-			rid, rt, param, f-eps, f+eps, lastUpdated,
+			`INSERT INTO sp_number (resource_id, resource_type, param_name, value, value_low, value_high, last_updated)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			rid, rt, param, f, f-eps, f+eps, lastUpdated,
 		)
 	}
 }

--- a/internal/index/extractor.go
+++ b/internal/index/extractor.go
@@ -44,13 +44,13 @@ func New(registry *searchparam.Registry) *Extractor {
 
 // Index extracts all search parameter values from resource and inserts them
 // into the sp_* tables within tx using a single batched round-trip.
-func (e *Extractor) Index(ctx context.Context, tx pgx.Tx, resourceType, resourceID string, resource map[string]any) error {
+func (e *Extractor) Index(ctx context.Context, tx pgx.Tx, resourceType, resourceID string, resource map[string]any, lastUpdated time.Time) error {
 	slog.Debug("Starting index extraction", "resourceType", resourceType, "resourceID", resourceID)
 	batch := &pgx.Batch{}
 
 	defs := e.registry.ForResource(resourceType)
 	for _, d := range defs {
-		e.queueParam(batch, resourceType, resourceID, resource, d)
+		e.queueParam(batch, resourceType, resourceID, resource, d, lastUpdated)
 	}
 	// Universal meta.* params (_tag/_security/_profile/_source) and the
 	// resource-level language. These live on Resource/DomainResource and so
@@ -139,10 +139,10 @@ func Delete(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) err
 // an external batch without sending it. The caller is responsible for sending
 // and draining the batch. This allows callers to merge index inserts with other
 // write operations into a single round-trip.
-func (e *Extractor) Queue(batch *pgx.Batch, resourceType, resourceID string, resource map[string]any) {
+func (e *Extractor) Queue(batch *pgx.Batch, resourceType, resourceID string, resource map[string]any, lastUpdated time.Time) {
 	defs := e.registry.ForResource(resourceType)
 	for _, d := range defs {
-		e.queueParam(batch, resourceType, resourceID, resource, d)
+		e.queueParam(batch, resourceType, resourceID, resource, d, lastUpdated)
 	}
 	queueMeta(batch, resourceType, resourceID, resource)
 }
@@ -171,7 +171,7 @@ func DeleteWithPool(ctx context.Context, pool *pgxpool.Pool, resourceType, resou
 	return tx.Commit(ctx)
 }
 
-func (e *Extractor) queueParam(batch *pgx.Batch, resourceType, resourceID string, resource map[string]any, d searchparam.Definition) {
+func (e *Extractor) queueParam(batch *pgx.Batch, resourceType, resourceID string, resource map[string]any, d searchparam.Definition, lastUpdated time.Time) {
 	vals, err := fhirpath.EvaluatePolymorphic(d.FHIRPath, resource)
 	if err != nil || len(vals) == 0 {
 		return
@@ -185,9 +185,9 @@ func (e *Extractor) queueParam(batch *pgx.Batch, resourceType, resourceID string
 	case "date", "dateTime", "instant", "Period":
 		queueDate(batch, resourceType, resourceID, d.ParamName, vals)
 	case "number":
-		queueNumber(batch, resourceType, resourceID, d.ParamName, vals)
+		queueNumber(batch, resourceType, resourceID, d.ParamName, vals, lastUpdated)
 	case "quantity":
-		queueQuantity(batch, resourceType, resourceID, d.ParamName, vals)
+		queueQuantity(batch, resourceType, resourceID, d.ParamName, vals, lastUpdated)
 	case "uri":
 		queueURI(batch, resourceType, resourceID, d.ParamName, vals)
 	case "reference":
@@ -400,7 +400,7 @@ func expandDateString(s string) (low, high time.Time, err error) {
 
 // ─── sp_number ────────────────────────────────────────────────────────────────
 
-func queueNumber(batch *pgx.Batch, rt, rid, param string, vals []any) {
+func queueNumber(batch *pgx.Batch, rt, rid, param string, vals []any, lastUpdated time.Time) {
 	for _, v := range vals {
 		f, ok := toFloat(v)
 		if !ok {
@@ -408,17 +408,19 @@ func queueNumber(batch *pgx.Batch, rt, rid, param string, vals []any) {
 		}
 		// ±5 ULP as implicit precision range
 		eps := math.Abs(f) * 1e-7
+		// last_updated mirrors resources.last_updated so the id-first fetch can
+		// sort candidates from idx_sp_num_range without a resources lookup.
 		batch.Queue(
-			`INSERT INTO sp_number (resource_id, resource_type, param_name, value_low, value_high)
-			 VALUES ($1, $2, $3, $4, $5)`,
-			rid, rt, param, f-eps, f+eps,
+			`INSERT INTO sp_number (resource_id, resource_type, param_name, value_low, value_high, last_updated)
+			 VALUES ($1, $2, $3, $4, $5, $6)`,
+			rid, rt, param, f-eps, f+eps, lastUpdated,
 		)
 	}
 }
 
 // ─── sp_quantity ──────────────────────────────────────────────────────────────
 
-func queueQuantity(batch *pgx.Batch, rt, rid, param string, vals []any) {
+func queueQuantity(batch *pgx.Batch, rt, rid, param string, vals []any, lastUpdated time.Time) {
 	for _, v := range vals {
 		m, ok := v.(map[string]any)
 		if !ok {
@@ -431,10 +433,12 @@ func queueQuantity(batch *pgx.Batch, rt, rid, param string, vals []any) {
 		sys := asString(m["system"])
 		code := asString(m["code"])
 		eps := math.Abs(f) * 1e-7
+		// last_updated mirrors resources.last_updated so the id-first fetch can
+		// sort candidates from idx_sp_qty_raw without a resources lookup.
 		batch.Queue(
-			`INSERT INTO sp_quantity (resource_id, resource_type, param_name, value, value_low, value_high, system, code)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			rid, rt, param, f, f-eps, f+eps, sys, code,
+			`INSERT INTO sp_quantity (resource_id, resource_type, param_name, value, value_low, value_high, system, code, last_updated)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			rid, rt, param, f, f-eps, f+eps, sys, code, lastUpdated,
 		)
 	}
 }

--- a/internal/index/extractor.go
+++ b/internal/index/extractor.go
@@ -55,7 +55,7 @@ func (e *Extractor) Index(ctx context.Context, tx pgx.Tx, resourceType, resource
 	// Universal meta.* params (_tag/_security/_profile/_source) and the
 	// resource-level language. These live on Resource/DomainResource and so
 	// aren't in the per-resource registry; index them uniformly for every type.
-	queueMeta(batch, resourceType, resourceID, resource)
+	queueMeta(batch, resourceType, resourceID, resource, lastUpdated)
 
 	if batch.Len() == 0 {
 		return nil
@@ -78,12 +78,12 @@ func (e *Extractor) Index(ctx context.Context, tx pgx.Tx, resourceType, resource
 //	_tag, _security  → sp_token  (Codings from meta.tag / meta.security)
 //	_profile, _source → sp_uri   (meta.profile URLs, meta.source URI)
 //	_language        → sp_token  (top-level language code)
-func queueMeta(batch *pgx.Batch, rt, rid string, resource map[string]any) {
+func queueMeta(batch *pgx.Batch, rt, rid string, resource map[string]any, lastUpdated time.Time) {
 	if meta, ok := resource["meta"].(map[string]any); ok {
 		for _, m := range []struct{ field, param string }{{"tag", "_tag"}, {"security", "_security"}} {
 			if arr, ok := meta[m.field].([]any); ok {
 				for _, c := range arr {
-					queueToken(batch, rt, rid, m.param, c)
+					queueToken(batch, rt, rid, m.param, c, lastUpdated)
 				}
 			}
 		}
@@ -96,9 +96,9 @@ func queueMeta(batch *pgx.Batch, rt, rid string, resource map[string]any) {
 	}
 	if lang := asString(resource["language"]); lang != "" {
 		batch.Queue(
-			`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display)
-			 VALUES ($1, $2, '_language', '', $3, '')`,
-			rid, rt, lang,
+			`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display, last_updated)
+			 VALUES ($1, $2, '_language', '', $3, '', $4)`,
+			rid, rt, lang, lastUpdated,
 		)
 	}
 }
@@ -144,7 +144,7 @@ func (e *Extractor) Queue(batch *pgx.Batch, resourceType, resourceID string, res
 	for _, d := range defs {
 		e.queueParam(batch, resourceType, resourceID, resource, d, lastUpdated)
 	}
-	queueMeta(batch, resourceType, resourceID, resource)
+	queueMeta(batch, resourceType, resourceID, resource, lastUpdated)
 }
 
 // QueueDelete adds one DELETE statement per sp_* table for the given resource
@@ -181,7 +181,7 @@ func (e *Extractor) queueParam(batch *pgx.Batch, resourceType, resourceID string
 	case "string":
 		queueString(batch, resourceType, resourceID, d.ParamName, vals)
 	case "token":
-		queueTokenValues(batch, resourceType, resourceID, d.ParamName, vals)
+		queueTokenValues(batch, resourceType, resourceID, d.ParamName, vals, lastUpdated)
 	case "date", "dateTime", "instant", "Period":
 		queueDate(batch, resourceType, resourceID, d.ParamName, vals)
 	case "number":
@@ -213,17 +213,17 @@ func queueString(batch *pgx.Batch, rt, rid, param string, vals []any) {
 
 // ─── sp_token ─────────────────────────────────────────────────────────────────
 
-func queueTokenValues(batch *pgx.Batch, rt, rid, param string, vals []any) {
+func queueTokenValues(batch *pgx.Batch, rt, rid, param string, vals []any, lastUpdated time.Time) {
 	for _, v := range vals {
 		switch val := v.(type) {
 		case map[string]any: // Coding or CodeableConcept
 			if codings, ok := val["coding"].([]any); ok {
 				for _, c := range codings {
-					queueToken(batch, rt, rid, param, c)
+					queueToken(batch, rt, rid, param, c, lastUpdated)
 				}
 			} else {
 				// Plain Coding
-				queueToken(batch, rt, rid, param, val)
+				queueToken(batch, rt, rid, param, val, lastUpdated)
 			}
 		case bool:
 			code := "false"
@@ -231,15 +231,15 @@ func queueTokenValues(batch *pgx.Batch, rt, rid, param string, vals []any) {
 				code = "true"
 			}
 			batch.Queue(
-				`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display)
-				 VALUES ($1, $2, $3, '', $4, '')`,
-				rid, rt, param, code,
+				`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display, last_updated)
+				 VALUES ($1, $2, $3, '', $4, '', $5)`,
+				rid, rt, param, code, lastUpdated,
 			)
 		case string:
 			batch.Queue(
-				`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display)
-				 VALUES ($1, $2, $3, '', $4, '')`,
-				rid, rt, param, val,
+				`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display, last_updated)
+				 VALUES ($1, $2, $3, '', $4, '', $5)`,
+				rid, rt, param, val, lastUpdated,
 			)
 		}
 	}
@@ -250,7 +250,7 @@ func queueTokenValues(batch *pgx.Batch, rt, rid, param string, vals []any) {
 // coding (system, code) plus the identifier value in the display column.
 const OfTypeSuffix = ":of-type"
 
-func queueToken(batch *pgx.Batch, rt, rid, param string, v any) {
+func queueToken(batch *pgx.Batch, rt, rid, param string, v any, lastUpdated time.Time) {
 	m, ok := v.(map[string]any)
 	if !ok {
 		return
@@ -268,9 +268,9 @@ func queueToken(batch *pgx.Batch, rt, rid, param string, v any) {
 		return
 	}
 	batch.Queue(
-		`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display)
-		 VALUES ($1, $2, $3, $4, $5, $6)`,
-		rid, rt, param, sys, code, display,
+		`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display, last_updated)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		rid, rt, param, sys, code, display, lastUpdated,
 	)
 
 	// :of-type support — only for Identifiers that carry a type.coding and a value.
@@ -290,9 +290,9 @@ func queueToken(batch *pgx.Batch, rt, rid, param string, v any) {
 						continue
 					}
 					batch.Queue(
-						`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display)
-						 VALUES ($1, $2, $3, $4, $5, $6)`,
-						rid, rt, param+OfTypeSuffix, tSys, tCode, value,
+						`INSERT INTO sp_token (resource_id, resource_type, param_name, system, code, display, last_updated)
+						 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+						rid, rt, param+OfTypeSuffix, tSys, tCode, value, lastUpdated,
 					)
 				}
 			}

--- a/internal/index/extractor_integration_test.go
+++ b/internal/index/extractor_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/wso2/fhir-server/internal/index"
@@ -88,7 +89,7 @@ func TestExtractor_IndexStringParam(t *testing.T) {
 	}
 	defer tx.Rollback(ctx)
 
-	if err := ext2.Index(ctx, tx, "Patient", "test-str-1", resource); err != nil {
+	if err := ext2.Index(ctx, tx, "Patient", "test-str-1", resource, time.Now()); err != nil {
 		t.Fatalf("Index: %v", err)
 	}
 	tx.Commit(ctx)
@@ -115,7 +116,7 @@ func TestExtractor_IndexTokenParam_FromGender(t *testing.T) {
 	tx, _ := pool.Begin(ctx)
 	defer tx.Rollback(ctx)
 
-	if err := ext.Index(ctx, tx, "Patient", "test-gender-1", resource); err != nil {
+	if err := ext.Index(ctx, tx, "Patient", "test-gender-1", resource, time.Now()); err != nil {
 		t.Fatalf("Index: %v", err)
 	}
 	tx.Commit(ctx)
@@ -142,7 +143,7 @@ func TestExtractor_IndexDateParam(t *testing.T) {
 	tx, _ := pool.Begin(ctx)
 	defer tx.Rollback(ctx)
 
-	if err := ext.Index(ctx, tx, "Patient", "test-bd-1", resource); err != nil {
+	if err := ext.Index(ctx, tx, "Patient", "test-bd-1", resource, time.Now()); err != nil {
 		t.Fatalf("Index: %v", err)
 	}
 	tx.Commit(ctx)
@@ -173,7 +174,7 @@ func TestExtractor_IndexReferenceParam(t *testing.T) {
 	tx, _ := pool.Begin(ctx)
 	defer tx.Rollback(ctx)
 
-	if err := ext.Index(ctx, tx, "Observation", "test-ref-obs-1", resource); err != nil {
+	if err := ext.Index(ctx, tx, "Observation", "test-ref-obs-1", resource, time.Now()); err != nil {
 		t.Fatalf("Index: %v", err)
 	}
 	tx.Commit(ctx)
@@ -210,7 +211,7 @@ func TestExtractor_IndexTokenParam_CodeableConcept(t *testing.T) {
 	tx, _ := pool.Begin(ctx)
 	defer tx.Rollback(ctx)
 
-	if err := ext.Index(ctx, tx, "Observation", "test-obs-code-1", resource); err != nil {
+	if err := ext.Index(ctx, tx, "Observation", "test-obs-code-1", resource, time.Now()); err != nil {
 		t.Fatalf("Index: %v", err)
 	}
 	tx.Commit(ctx)
@@ -240,7 +241,7 @@ func TestExtractor_Delete_ClearsAllSpTables(t *testing.T) {
 	insertResource(t, pool, "Patient", rid, resource)
 
 	tx, _ := pool.Begin(ctx)
-	ext.Index(ctx, tx, "Patient", rid, resource)
+	ext.Index(ctx, tx, "Patient", rid, resource, time.Now())
 	tx.Commit(ctx)
 
 	tx2, _ := pool.Begin(ctx)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -252,7 +252,7 @@ type queryBuilder struct {
 	// direct-drive fetch reuses it in its resources JOIN so that placeholder stays
 	// referenced — a parameter bound but never used trips Postgres' type inference
 	// (SQLSTATE 42P18), which the direct-drive shape would otherwise hit because it
-	// builds its WHERE from driveBodies rather than b.where.
+	// builds its WHERE from numericBodies rather than b.where.
 	rtParam string
 	sort    []sortKey
 	// usesSP is set when a positive value predicate against a numeric,
@@ -262,22 +262,21 @@ type queryBuilder struct {
 	// degrades to for sparse result sets on those tables.
 	usesSP bool
 	// predicateCount counts the top-level value predicates added (one per and()).
-	// With driveTable/driveBodies it gates the direct-drive id-first fetch (see
+	// With numericTable/numericBodies it gates the direct-drive id-first fetch (see
 	// fetchSQL): a search whose sole predicate (predicateCount == 1) is a numeric
 	// value match can drive the candidate CTE straight off the sp_* value index.
 	predicateCount int
-	// driveTable / driveBodies capture the non-correlated candidate source for a
-	// drivable predicate — a numeric (quantity/number) value match or a code-token
-	// match — as the sp_* table plus the predicate on alias s with the
-	// s.resource_id = r.fhir_id correlation stripped (comma-OR values append one
-	// body each). When the search is a lone such predicate sorted by a resources
-	// column, fetchSQL drives the candidate resolve straight off that table's
-	// recency index (idx_sp_qty_recent / idx_sp_num_recent / idx_sp_tok_recent),
-	// newest-first with the sort key from the denormalised last_updated, instead of
-	// walking resources with a correlated EXISTS. Both the sparse and dense case
-	// early-exit index-only — no per-match resources lookup.
-	driveTable  string
-	driveBodies []string
+	// numericTable / numericBodies capture the non-correlated candidate source for
+	// a numeric (quantity/number) predicate — the sp_* table and the predicate on
+	// alias s with the s.resource_id = r.fhir_id correlation stripped (comma-OR
+	// values append one body each). When the search turns out to be a lone numeric
+	// predicate sorted by a resources column, fetchSQL drives the id-first CTE off
+	// these instead of scanning resources with a correlated EXISTS. Since sp_* rows
+	// carry a denormalised last_updated in the covering index, both the sparse and
+	// the dense case resolve index-only — no per-match resources lookup, and no
+	// density probe.
+	numericTable  string
+	numericBodies []string
 	// comp captures a composite search (e.g. code-value-quantity) as a two-table
 	// drive: resolve candidate resource_ids from the selective token component's
 	// sp_* table, filtered by the other component as a nested EXISTS, before
@@ -290,7 +289,7 @@ type queryBuilder struct {
 	// suppressDirectDrive is set while a nested value predicate is being built —
 	// a composite component (buildCompositeExists), a chained target
 	// (buildChainedCondition), or a _has value (applyHas). In those contexts the
-	// numeric builders would otherwise capture driveTable/driveBodies, and a
+	// numeric builders would otherwise capture numericTable/numericBodies, and a
 	// lone such predicate would then wrongly satisfy directDrive() — emitting only
 	// that embedded numeric body and dropping the surrounding structure (wrong
 	// results, plus orphaned params → SQLSTATE 42P18). Capture is skipped while
@@ -444,17 +443,12 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 
 	if expr := b.combinedExists(param, modifier, value); expr != "" {
 		b.and(expr)
-		// Route this search through the id-first fetch strategy when it can be
-		// resolved off an sp_* recency index instead of the resources
-		// recency-walk. Two triggers:
-		//   - paramUsesIdFirst: quantity/number/composite, which the planner
-		//     mis-estimates for an unbounded numeric range (see idFirstType).
-		//   - a captured drive candidate (b.driveTable): a lone code-token search,
-		//     which the planner otherwise resolves by walking resources and probing
-		//     sp_token per row rather than driving from idx_sp_tok_recent.
-		// reference, date, string, uri and system-only / :text tokens capture no
-		// drive candidate and keep the early-terminating ordered scan.
-		if b.paramUsesIdFirst(param) || b.driveTable != "" {
+		// Route this search through the id-first fetch strategy only for the
+		// numeric sp_* predicates the planner mis-estimates (quantity/number, and
+		// composite which embeds one — see idFirstType). token, reference, date,
+		// string and uri params keep the early-terminating ordered scan, where the
+		// planner has good enough statistics to pick the right plan itself.
+		if b.paramUsesIdFirst(param) {
 			b.usesSP = true
 		}
 	}
@@ -1017,17 +1011,12 @@ func idFirstType(paramType string) bool {
 	// quantity/number range predicates (and composite, which embeds one) are
 	// mis-estimated by the planner — it cannot judge the selectivity of an
 	// unbounded numeric range, so without the id-first barrier it may choose the
-	// ordered scan and walk the whole table for a sparse match set.
-	//
-	// token is NOT here: it is routed to id-first differently — buildTokenExists
-	// captures a drive candidate (b.driveTable) for a code-equality match, and
-	// applySearchParam flips usesSP on that. This matters because the planner does
-	// NOT reliably drive selective code searches off sp_token — for a sort by
-	// recency + LIMIT it prefers to walk resources by last_updated and probe
-	// sp_token per row, scanning thousands of rows for a code that matches ~0.3%
-	// of resources (measured 77k buffers vs 134 for the id-first shape). Driving
-	// off idx_sp_tok_recent early-exits for both sparse and dense codes, so it is
-	// safe to force; system-only / :text tokens capture nothing and keep the scan.
+	// ordered scan and walk the whole table for a sparse match set. token is
+	// deliberately NOT here: token equality has reliable MCV statistics, so the
+	// planner already resolves id-first for selective/empty codes and takes the
+	// ordered early-exit for dense ones. Forcing id-first on tokens instead
+	// pessimises the common dense case (e.g. a category code matching most rows),
+	// which then has to materialize and sort the entire match set.
 	case "quantity", "number", "composite":
 		return true
 	default:
@@ -1098,49 +1087,28 @@ func (b *queryBuilder) buildTokenExists(param, modifier, value string) string {
 	rtP := b.next(b.rt)
 	pP := b.next(param)
 	// :text matches the human-readable display/text of the token (case-insensitive
-	// substring), not its code — it can't drive off the code recency index, so no
-	// drive candidate is captured and it keeps the ordered scan.
+	// substring), not its code.
 	if modifier == "text" {
 		vP := b.next("%" + strings.ToLower(value) + "%")
 		return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND LOWER(s.display) LIKE %s", rtP, pP, vP)
 	}
-	// cond is the correlation-free predicate on alias s. hasCode marks a
-	// code-equality predicate — only those can drive off idx_sp_tok_recent, whose
-	// key is (…, code, last_updated DESC) and which is partial on code IS NOT NULL.
-	var cond string
-	hasCode := false
 	parts := strings.SplitN(value, "|", 2)
 	if len(parts) == 2 {
 		sys, code := parts[0], parts[1]
-		switch {
-		case sys == "": // |code
-			cond = fmt.Sprintf("s.code = %s", b.next(code))
-			hasCode = true
-		case code == "": // system|
-			cond = fmt.Sprintf("s.system = %s", b.next(sys))
-		default: // system|code
-			sP := b.next(sys)
+		if sys == "" {
 			cP := b.next(code)
-			cond = fmt.Sprintf("s.system = %s AND s.code = %s", sP, cP)
-			hasCode = true
+			return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.code = %s", rtP, pP, cP)
 		}
-	} else {
-		cond = fmt.Sprintf("s.code = %s", b.next(value))
-		hasCode = true
+		if code == "" {
+			sP := b.next(sys)
+			return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.system = %s", rtP, pP, sP)
+		}
+		sP := b.next(sys)
+		cP := b.next(code)
+		return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.system = %s AND s.code = %s", rtP, pP, sP, cP)
 	}
-	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
-	// Capture a drive candidate so a lone token search resolves id-first off
-	// idx_sp_tok_recent — walking sp_token newest-first for the code and
-	// early-exiting at the page — instead of the resources recency-walk, which
-	// scans thousands of resource rows probing sp_token per row (measured 77k
-	// buffers vs 134 for the id-first shape). Only a code-equality body qualifies;
-	// a system-only or :text predicate keeps the ordered scan. Skipped in a nested
-	// context (composite / chained / _has), like the numeric builders.
-	if hasCode && !b.suppressDirectDrive {
-		b.driveTable = "sp_token"
-		b.driveBodies = append(b.driveBodies, body)
-	}
-	return "SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND " + body
+	vP := b.next(value)
+	return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.code = %s", rtP, pP, vP)
 }
 
 // buildTokenInExists expands a ValueSet URL and builds an IN/NOT IN subquery
@@ -1313,8 +1281,8 @@ func (b *queryBuilder) buildNumberExists(param, value string) string {
 	// id-first CTE straight off sp_number (see fetchSQL). Skipped inside a nested
 	// context (composite / chained / _has), whose full predicate is more than this.
 	if !b.suppressDirectDrive {
-		b.driveTable = "sp_number"
-		b.driveBodies = append(b.driveBodies, body)
+		b.numericTable = "sp_number"
+		b.numericBodies = append(b.numericBodies, body)
 	}
 	return "SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND " + body
 }
@@ -1413,8 +1381,8 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	// shared with the EXISTS form below. Skipped inside a nested context (composite
 	// / chained / _has), whose full predicate is more than this one body.
 	if !b.suppressDirectDrive {
-		b.driveTable = "sp_quantity"
-		b.driveBodies = append(b.driveBodies, body)
+		b.numericTable = "sp_quantity"
+		b.numericBodies = append(b.numericBodies, body)
 	}
 	return "SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND " + body
 }
@@ -1824,12 +1792,12 @@ func (b *queryBuilder) fetchSQL(limit, offset int) string {
 // directDrive reports whether the search is a lone numeric (quantity/number)
 // value predicate sorted by a resources column, so the id-first candidate CTE can
 // be driven straight off the sp_* value index (see directDriveSQL) instead of a
-// correlated EXISTS over resources. driveTable/driveBodies hold the captured
+// correlated EXISTS over resources. numericTable/numericBodies hold the captured
 // scan; predicateCount == 1 guarantees the bodies fully express the match (no
 // other WHERE predicate); orderByResourceIndex keeps the sort mappable to the
 // sp_* columns (last_updated / resource_id).
 func (b *queryBuilder) directDrive(terms []orderTerm) bool {
-	return b.driveTable != "" && len(b.driveBodies) > 0 &&
+	return b.numericTable != "" && len(b.numericBodies) > 0 &&
 		b.predicateCount == 1 && orderByResourceIndex(terms)
 }
 
@@ -1904,7 +1872,7 @@ func (b *queryBuilder) compositeDriveSQL(terms []orderTerm, limit, offset int) s
 // the numeric sp_* value index. The sort keys map from their resources columns to
 // the denormalised sp_* columns (r.last_updated → s.last_updated, r.fhir_id →
 // s.resource_id), both covered by the value index, so the candidate resolve is
-// index-only. The driveBodies reuse the $N args already bound during predicate
+// index-only. The numericBodies reuse the $N args already bound during predicate
 // building; only limit/offset/rt are appended here.
 func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) string {
 	selectList := []string{"s.resource_id AS fhir_id"}
@@ -1915,9 +1883,9 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 		innerOrder = append(innerOrder, alias+" "+t.dir)
 		outerOrder = append(outerOrder, "c."+alias+" "+t.dir)
 	}
-	match := b.driveBodies[0]
-	if len(b.driveBodies) > 1 {
-		match = "(" + strings.Join(b.driveBodies, " OR ") + ")"
+	match := b.numericBodies[0]
+	if len(b.numericBodies) > 1 {
+		match = "(" + strings.Join(b.numericBodies, " OR ") + ")"
 	}
 	limitP := b.next(limit)
 	offsetP := b.next(offset)
@@ -1953,7 +1921,7 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 			AND r.is_deleted = FALSE
 		ORDER BY %s`,
 		strings.Join(selectList, ", "),
-		b.driveTable, match,
+		b.numericTable, match,
 		strings.Join(innerOrder, ", "), limitP, offsetP,
 		b.rtParam,
 		strings.Join(outerOrder, ", "),

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -255,13 +255,21 @@ type queryBuilder struct {
 	// degrades to for sparse result sets on those tables.
 	usesSP bool
 	// predicateCount counts the top-level value predicates added (one per and()).
-	// numericSP is set when a quantity/number param is added. Together they gate
-	// the dense probe (see probeDense): it runs only for a search whose sole
-	// predicate is numeric, where the LIMIT-bounded probe is cheap. A token or
-	// composite predicate would make the probe scan a large match set, so those
-	// (and any multi-predicate search) keep the id-first shape unconditionally.
+	// With numericTable/numericBodies it gates the direct-drive id-first fetch (see
+	// fetchSQL): a search whose sole predicate (predicateCount == 1) is a numeric
+	// value match can drive the candidate CTE straight off the sp_* value index.
 	predicateCount int
-	numericSP      bool
+	// numericTable / numericBodies capture the non-correlated candidate source for
+	// a numeric (quantity/number) predicate — the sp_* table and the predicate on
+	// alias s with the s.resource_id = r.fhir_id correlation stripped (comma-OR
+	// values append one body each). When the search turns out to be a lone numeric
+	// predicate sorted by a resources column, fetchSQL drives the id-first CTE off
+	// these instead of scanning resources with a correlated EXISTS. Since sp_* rows
+	// carry a denormalised last_updated in the covering index, both the sparse and
+	// the dense case resolve index-only — no per-match resources lookup, and no
+	// density probe.
+	numericTable  string
+	numericBodies []string
 	// err is set when the request can't be satisfied (e.g. a registry-known
 	// param of unsupported type like composite/special). Search() returns it
 	// as an UnsupportedParamError rather than silently widening the result set.
@@ -402,9 +410,6 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 		// planner has good enough statistics to pick the right plan itself.
 		if b.paramUsesIdFirst(param) {
 			b.usesSP = true
-		}
-		if b.paramIsNumeric(param) {
-			b.numericSP = true
 		}
 	}
 }
@@ -780,23 +785,6 @@ func (b *queryBuilder) paramUsesIdFirst(param string) bool {
 	return false
 }
 
-// paramIsNumeric reports whether param maps to a bare numeric sp_* table
-// (quantity/number). These are exactly the predicates whose selectivity the
-// dense probe can measure cheaply via a LIMIT-bounded index scan, so probeDense
-// only engages for a search whose sole predicate is one of them. composite is
-// excluded: it embeds a token whose match set the probe would have to scan.
-func (b *queryBuilder) paramIsNumeric(param string) bool {
-	pt := ""
-	if t, ok := universalParamType[param]; ok {
-		pt = t
-	} else if b.reg != nil {
-		if def, ok := b.reg.Lookup(b.rt, param); ok {
-			pt = def.ParamType
-		}
-	}
-	return pt == "quantity" || pt == "number"
-}
-
 func idFirstType(paramType string) bool {
 	switch paramType {
 	// quantity/number range predicates (and composite, which embeds one) are
@@ -1056,18 +1044,23 @@ func (b *queryBuilder) buildNumberExists(param, value string) string {
 	}
 	rtP := b.next(b.rt)
 	pP := b.next(param)
+	var cond string
 	switch prefix {
 	case "gt":
-		vP := b.next(f)
-		return fmt.Sprintf("SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.value_high > %s", rtP, pP, vP)
+		cond = fmt.Sprintf("s.value_high > %s", b.next(f))
 	case "lt":
-		vP := b.next(f)
-		return fmt.Sprintf("SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.value_low < %s", rtP, pP, vP)
+		cond = fmt.Sprintf("s.value_low < %s", b.next(f))
 	default: // eq
 		highP := b.next(f + eps)
 		lowP := b.next(f - eps)
-		return fmt.Sprintf("SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.value_low <= %s AND s.value_high >= %s", rtP, pP, highP, lowP)
+		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", highP, lowP)
 	}
+	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
+	// Capture the correlation-free body so a lone number predicate can drive the
+	// id-first CTE straight off sp_number (see fetchSQL).
+	b.numericTable = "sp_number"
+	b.numericBodies = append(b.numericBodies, body)
+	return "SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND " + body
 }
 
 // buildReferenceExists matches a reference param against sp_reference. It accepts
@@ -1152,14 +1145,19 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", hP, lP)
 	}
 
-	q := fmt.Sprintf("SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
+	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
 	if system != "" {
-		q += fmt.Sprintf(" AND s.system = %s", b.next(system))
+		body += fmt.Sprintf(" AND s.system = %s", b.next(system))
 	}
 	if code != "" {
-		q += fmt.Sprintf(" AND s.code = %s", b.next(code))
+		body += fmt.Sprintf(" AND s.code = %s", b.next(code))
 	}
-	return q
+	// Capture the correlation-free body so a lone quantity predicate can drive the
+	// id-first CTE straight off sp_quantity (see fetchSQL). The same $N args are
+	// shared with the EXISTS form below.
+	b.numericTable = "sp_quantity"
+	b.numericBodies = append(b.numericBodies, body)
+	return "SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND " + body
 }
 
 // buildURIExists matches a uri param against sp_uri. Default is an exact match.
@@ -1445,11 +1443,7 @@ func (s *Store) LastN(ctx context.Context, params map[string][]string, maxN int)
 }
 
 func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset int) ([]map[string]any, error) {
-	dense, err := b.probeDense(ctx, pool)
-	if err != nil {
-		return nil, err
-	}
-	q := b.fetchSQL(limit, offset, dense)
+	q := b.fetchSQL(limit, offset)
 
 	rows, err := pool.Query(ctx, q, b.args...)
 	if err != nil {
@@ -1478,34 +1472,36 @@ func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset in
 // (for _sort on search params) before LIMIT/OFFSET, keeping b.args ordered as
 // [where args…, order-by args…, limit, offset, …].
 //
-// Two query shapes are produced:
+// Three query shapes are produced:
 //
-//   - Single-scan form (no numeric sp_* predicate, or dense == true): ORDER BY
-//     r.last_updated served directly by idx_res_active, so the LIMIT terminates
-//     early after `limit` rows without visiting the whole match set. Used for
-//     plain browse, resources-column filters, token/reference/etc. predicates
-//     (the planner picks the right plan from their statistics), and numeric
-//     predicates the probe has confirmed are dense.
+//   - Single-scan form (no id-first sp_* predicate): ORDER BY r.last_updated
+//     served directly by idx_res_active, so the LIMIT terminates early after
+//     `limit` rows without visiting the whole match set. Used for plain browse,
+//     resources-column filters, and token/reference/date/string/uri predicates,
+//     where the planner has good enough statistics to pick the right plan.
 //
-//   - id-first form (numeric sp_* predicate, dense == false): a MATERIALIZED CTE
-//     resolves the matching (fhir_id, sort keys) first, so the planner drives the
-//     match off the selective sp_* index instead of scanning resources in
-//     last_updated order and probing sp_* per candidate row. The sort + LIMIT run
-//     over the light candidate rows, then the surviving page joins back for
-//     resource_json.
+//   - Direct-drive id-first form (a lone numeric quantity/number predicate sorted
+//     by a resources column — see directDrive): a MATERIALIZED CTE resolves the
+//     matching (resource_id, sort keys) straight off the sp_* value index. Because
+//     sp_* carries a denormalised last_updated in the covering index, the resolve
+//     is index-only for both a sparse match set (returns in well under a
+//     millisecond) and a dense one (a bounded index scan + top-N sort), so no
+//     density probe is needed. The surviving page then joins resources for JSON.
 //
-// The MATERIALIZED barrier is load-bearing for a sparse numeric predicate:
-// without it the planner (which cannot estimate an unbounded numeric range)
-// collapses into the single-scan shape and does a full resources scan with a
-// per-row sp_* probe that never reaches the LIMIT — multiple seconds per query on
-// the perf dataset. For a dense numeric predicate that same single-scan shape is
-// instead the fast plan (a page's worth of matches sits in the first handful of
-// rows), so probeDense measures the density up front and passes dense=true to
-// switch back to it.
-func (b *queryBuilder) fetchSQL(limit, offset int, dense bool) string {
+//   - Correlated id-first form (composite, or a multi-predicate search embedding a
+//     numeric one): a MATERIALIZED CTE resolves (fhir_id, sort keys) from resources
+//     with the correlated EXISTS predicates, so the planner still drives the match
+//     off the selective sp_* index rather than scanning resources in last_updated
+//     order. Used when the candidate set cannot be expressed as a single sp_* scan.
+//
+// The MATERIALIZED barrier is load-bearing for a sparse numeric predicate: without
+// it the planner (which cannot estimate an unbounded numeric range) collapses into
+// the single-scan shape and does a full resources scan with a per-row sp_* probe
+// that never reaches the LIMIT — multiple seconds per query on the perf dataset.
+func (b *queryBuilder) fetchSQL(limit, offset int) string {
 	terms := b.orderTerms()
 
-	if !b.usesSP || dense {
+	if !b.usesSP {
 		var clauses []string
 		for _, t := range terms {
 			clauses = append(clauses, t.expr+" "+t.dir)
@@ -1522,8 +1518,12 @@ func (b *queryBuilder) fetchSQL(limit, offset int, dense bool) string {
 		)
 	}
 
-	// id-first: compute fhir_id plus each sort key once in the candidate CTE,
-	// carry them through the LIMIT, then re-apply the sort after the json join.
+	if b.directDrive() {
+		return b.directDriveSQL(terms, limit, offset)
+	}
+
+	// Correlated id-first: compute fhir_id plus each sort key once in the candidate
+	// CTE, carry them through the LIMIT, then re-apply the sort after the json join.
 	selectList := []string{"r.fhir_id"}
 	innerCols := []string{"fhir_id"}
 	var innerOrder, outerOrder []string
@@ -1558,41 +1558,76 @@ func (b *queryBuilder) fetchSQL(limit, offset int, dense bool) string {
 	)
 }
 
-// denseCandidateThreshold is the match-set size at which the single-scan fetch
-// overtakes the id-first MATERIALIZED fetch for a numeric predicate. Below it the
-// id-first form resolves and sorts a small candidate set cheaply; above it that
-// set is large, and materializing+sorting all of it costs more than letting the
-// ordered scan walk idx_res_active and stop at the page. Measured crossover was
-// ~1.5k rows on the perf dataset; 1000 is a slightly conservative round value.
-const denseCandidateThreshold = 1000
+// directDrive reports whether the search is a lone numeric (quantity/number)
+// value predicate sorted by a resources column, so the id-first candidate CTE can
+// be driven straight off the sp_* value index (see directDriveSQL) instead of a
+// correlated EXISTS over resources. numericTable/numericBodies hold the captured
+// scan; predicateCount == 1 guarantees the bodies fully express the match (no
+// other WHERE predicate); orderByResourceIndex keeps the sort mappable to the
+// sp_* columns (last_updated / resource_id).
+func (b *queryBuilder) directDrive() bool {
+	return b.numericTable != "" && len(b.numericBodies) > 0 &&
+		b.predicateCount == 1 && b.orderByResourceIndex()
+}
 
-// probeDense reports whether a numeric search's match set is large enough that
-// fetchSQL should use the ordered single-scan shape instead of the id-first
-// MATERIALIZED one.
-//
-// It runs only for a search whose sole predicate is numeric (quantity/number)
-// and whose sort is served by the resources index (see orderByResourceIndex).
-// That restriction keeps the check cheap: the LIMIT-bounded probe resolves off
-// the numeric sp_* index — a sparse predicate returns in well under a
-// millisecond, a dense one hits the LIMIT after scanning few rows. token and
-// composite predicates are excluded because their probe would scan a large token
-// match set (and composites are almost always sparse anyway); multi-predicate
-// searches are excluded because the extra predicates make the probe expensive.
-// It reuses b.args as-is (the LIMIT is a constant), so it must run before
-// fetchSQL appends the ORDER BY / LIMIT / OFFSET parameters.
-func (b *queryBuilder) probeDense(ctx context.Context, pool querier) (bool, error) {
-	if !b.numericSP || b.predicateCount != 1 || !b.orderByResourceIndex() {
-		return false, nil
+// directDriveSQL builds the id-first fetch that resolves candidates directly from
+// the numeric sp_* value index. The sort keys map from their resources columns to
+// the denormalised sp_* columns (r.last_updated → s.last_updated, r.fhir_id →
+// s.resource_id), both covered by the value index, so the candidate resolve is
+// index-only. The numericBodies reuse the $N args already bound during predicate
+// building; only limit/offset/rt are appended here.
+func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) string {
+	selectList := []string{"s.resource_id AS fhir_id"}
+	innerCols := []string{"fhir_id"}
+	var innerOrder, outerOrder []string
+	for i, t := range terms {
+		alias := fmt.Sprintf("sort%d", i)
+		selectList = append(selectList, directDriveSortExpr(t.expr)+" AS "+alias)
+		innerCols = append(innerCols, alias)
+		innerOrder = append(innerOrder, alias+" "+t.dir)
+		outerOrder = append(outerOrder, "c."+alias+" "+t.dir)
 	}
-	q := fmt.Sprintf(
-		`SELECT count(*) FROM (SELECT 1 FROM resources r WHERE %s LIMIT %d) probe`,
-		b.where.String(), denseCandidateThreshold,
+	match := b.numericBodies[0]
+	if len(b.numericBodies) > 1 {
+		match = "(" + strings.Join(b.numericBodies, " OR ") + ")"
+	}
+	limitP := b.next(limit)
+	offsetP := b.next(offset)
+	rtP := b.next(b.rt)
+
+	return fmt.Sprintf(`
+		WITH candidates AS MATERIALIZED (
+			SELECT %s
+			FROM %s s
+			WHERE s.tenant_id = current_setting('app.current_tenant', true) AND %s
+		)
+		SELECT r.resource_json, r.version_id, r.last_updated
+		FROM (SELECT %s FROM candidates ORDER BY %s LIMIT %s OFFSET %s) c
+		JOIN resources r ON r.fhir_id = c.fhir_id
+			AND r.resource_type = %s
+			AND r.tenant_id = current_setting('app.current_tenant', true)
+			AND r.is_deleted = FALSE
+		ORDER BY %s`,
+		strings.Join(selectList, ", "),
+		b.numericTable, match,
+		strings.Join(innerCols, ", "), strings.Join(innerOrder, ", "), limitP, offsetP,
+		rtP,
+		strings.Join(outerOrder, ", "),
 	)
-	var n int
-	if err := pool.QueryRow(ctx, q, b.args...).Scan(&n); err != nil {
-		return false, err
+}
+
+// directDriveSortExpr maps a resources-column ORDER BY expression to the
+// equivalent denormalised sp_* column for the direct-drive candidate CTE. Only
+// reached for the two columns orderByResourceIndex admits.
+func directDriveSortExpr(resExpr string) string {
+	switch resExpr {
+	case "r.last_updated":
+		return "s.last_updated"
+	case "r.fhir_id":
+		return "s.resource_id"
+	default:
+		return resExpr
 	}
-	return n >= denseCandidateThreshold, nil
 }
 
 // orderByResourceIndex reports whether every ORDER BY term is a plain resources

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -276,6 +277,15 @@ type queryBuilder struct {
 	// density probe.
 	numericTable  string
 	numericBodies []string
+	// comp captures a composite search (e.g. code-value-quantity) as a two-table
+	// drive: resolve candidate resource_ids from the selective token component's
+	// sp_* table, filtered by the other component as a nested EXISTS, before
+	// touching resources. Set only when the composite is the sole predicate, one
+	// component is a token (a selective equality driver), and the sort maps to a
+	// resources column. compositeDriveSQL uses it instead of the correlated
+	// id-first CTE, which otherwise joins resources for every single-component
+	// match before intersecting (measured 255ms → 88ms on the perf dataset).
+	comp *compositeDrive
 	// suppressDirectDrive is set while a nested value predicate is being built —
 	// a composite component (buildCompositeExists), a chained target
 	// (buildChainedCondition), or a _has value (applyHas). In those contexts the
@@ -523,6 +533,13 @@ func (b *queryBuilder) buildCompositeExists(def searchparam.Definition, param, v
 	if !ok1 || !ok2 || cond1 == "" || cond2 == "" {
 		return "", false
 	}
+	// At the top level (not nested inside a chained/_has/composite context),
+	// capture a two-table drive so fetchSQL can resolve candidates from the
+	// selective token component instead of the resources recency-walk / correlated
+	// CTE. Nested composites keep the correlated shape (prev == true).
+	if !prev {
+		b.captureCompositeDrive(comp1Name, cond1, comp2Name, cond2)
+	}
 	// Nest cond2 as a correlated EXISTS inside cond1's WHERE. The caller
 	// (combinedExists) wraps our return value in a single EXISTS(...), producing
 	//   EXISTS (cond1 … AND EXISTS (cond2 …))
@@ -532,6 +549,77 @@ func (b *queryBuilder) buildCompositeExists(def searchparam.Definition, param, v
 	// semi-joins driven by the more selective component's sp_* index, rather
 	// than a correlated subplan run once per candidate resource row.
 	return cond1 + " AND EXISTS (" + cond2 + ")", true
+}
+
+// compositeDrive holds a composite search decomposed into a candidate driver
+// (the selective token component's sp_* table) and a filter (the other
+// component, applied as a nested EXISTS correlated to the driver row). Both
+// bodies are correlation-free WHERE fragments; driverBody references alias s and
+// filterBody references alias s2. The $N placeholders they contain were bound
+// while the components were built, so compositeDriveSQL reuses them verbatim.
+type compositeDrive struct {
+	driverTable string
+	driverBody  string
+	filterTable string
+	filterBody  string
+}
+
+// captureCompositeDrive records a two-table drive for the composite when one
+// component is a token (a selective equality driver). cond1/cond2 are the
+// fully-formed correlated component subqueries. If neither component is a token,
+// or either body is too complex to safely re-alias, capture is skipped and the
+// search keeps the correlated id-first CTE.
+func (b *queryBuilder) captureCompositeDrive(name1, cond1, name2, cond2 string) {
+	t1, body1, ok1 := splitSimpleExists(cond1)
+	t2, body2, ok2 := splitSimpleExists(cond2)
+	if !ok1 || !ok2 {
+		return
+	}
+	tok1 := b.resolvedParamType(name1) == "token"
+	tok2 := b.resolvedParamType(name2) == "token"
+	var drvTable, drvBody, fltTable, fltBody string
+	switch {
+	case tok1:
+		drvTable, drvBody, fltTable, fltBody = t1, body1, t2, body2
+	case tok2:
+		drvTable, drvBody, fltTable, fltBody = t2, body2, t1, body1
+	default:
+		return // no selective equality driver — keep the correlated id-first CTE
+	}
+	b.comp = &compositeDrive{
+		driverTable: drvTable,
+		driverBody:  drvBody,
+		filterTable: fltTable,
+		// The filter runs as a nested EXISTS under alias s2 correlated to the
+		// driver's resource_id; re-alias its column references from s to s2. The
+		// body only ever references s.<column> (never a literal "s." — values are
+		// $N placeholders), so a plain replace is safe.
+		filterBody: strings.ReplaceAll(fltBody, "s.", "s2."),
+	}
+}
+
+// splitSimpleExists decomposes a component subquery of the exact shape
+// "SELECT 1 FROM <table> s WHERE s.resource_id = r.fhir_id AND <body>" into its
+// table and correlation-free body. Returns ok=false for any other shape (token
+// :in / heuristic UNION, terminology hierarchy, etc.) that embeds a further
+// SELECT and cannot be safely re-aliased into a driver row.
+func splitSimpleExists(cond string) (table, body string, ok bool) {
+	const pfx = "SELECT 1 FROM "
+	const mid = " s WHERE s.resource_id = r.fhir_id AND "
+	if !strings.HasPrefix(cond, pfx) {
+		return "", "", false
+	}
+	rest := cond[len(pfx):]
+	i := strings.Index(rest, mid)
+	if i < 0 {
+		return "", "", false
+	}
+	table = rest[:i]
+	body = rest[i+len(mid):]
+	if strings.Contains(body, "SELECT") || strings.Contains(body, "UNION") {
+		return "", "", false
+	}
+	return table, body, true
 }
 
 // resolveComponentName converts a component expression like "code",
@@ -717,6 +805,20 @@ func (b *queryBuilder) buildChainedCondition(sourceType, ref, targetType, target
 // combinedExists builds the EXISTS predicate for a (possibly comma-separated)
 // value, OR-joining the parts. Returns "" when no part produced a condition.
 func (b *queryBuilder) combinedExists(param, modifier, value string) string {
+	// Multi-value reference searches (comma = logical OR): coalesce the targets
+	// into a single EXISTS with target_id = ANY(...) rather than OR-ing separate
+	// EXISTS subqueries. A lone EXISTS lets Postgres invert the plan and drive
+	// from the selective sp_reference target index; OR-of-EXISTS defeats that
+	// inversion and collapses to a full recency-walk over resources — measured on
+	// the perf dataset at 360ms / 672k buffers for an empty match set, vs
+	// 0.1ms / 19 buffers for the ANY form. :identifier is excluded (it matches on
+	// identifier_system/value, not target_id).
+	if modifier != "identifier" && strings.IndexByte(value, ',') >= 0 && b.resolvedParamType(param) == "reference" {
+		if expr, ok := b.buildReferenceAnyExists(param, modifier, value); ok {
+			return expr
+		}
+		// Fall through to the generic OR form if the values could not be coalesced.
+	}
 	var ors []string
 	for _, p := range strings.Split(value, ",") {
 		cond, ok := b.buildExistsForValue(param, modifier, strings.TrimSpace(p))
@@ -732,6 +834,79 @@ func (b *queryBuilder) combinedExists(param, modifier, value string) string {
 	default:
 		return "(" + strings.Join(ors, " OR ") + ")"
 	}
+}
+
+// resolvedParamType returns the FHIR search param type for param on the current
+// resource type, resolving universal meta params first, then the registry.
+// Returns "" when the type is unknown (heuristic path).
+func (b *queryBuilder) resolvedParamType(param string) string {
+	if pt, ok := universalParamType[param]; ok {
+		return pt
+	}
+	if b.reg != nil {
+		if def, ok := b.reg.Lookup(b.rt, param); ok {
+			return def.ParamType
+		}
+	}
+	return ""
+}
+
+// buildReferenceAnyExists builds a single EXISTS predicate for a multi-value
+// reference search, matching any of the comma-separated targets via
+// target_id = ANY(...). Values are grouped by target_type so a mixed-type list
+// (e.g. subject=Patient/1,Group/2) stays correct; each group contributes one
+// ANY clause OR-ed inside the single EXISTS. Bare ids (no Type/ prefix and no
+// type modifier) form an untyped group. Returns ok=false if any value has no
+// id, so the caller falls back to the generic OR-of-EXISTS form.
+func (b *queryBuilder) buildReferenceAnyExists(param, modifier, value string) (string, bool) {
+	rtP := b.next(b.rt)
+	pP := b.next(param)
+
+	typed := map[string][]string{} // target_type -> ids
+	var bare []string              // ids with no explicit type
+	for _, part := range strings.Split(value, ",") {
+		typ, id := parseSearchReference(strings.TrimSpace(part))
+		if typ == "" && modifier != "" {
+			// e.g. subject:Patient=1,2 — the modifier names the target type.
+			typ = modifier
+		}
+		if id == "" {
+			return "", false
+		}
+		if typ != "" {
+			typed[typ] = append(typed[typ], id)
+		} else {
+			bare = append(bare, id)
+		}
+	}
+
+	var clauses []string
+	types := make([]string, 0, len(typed))
+	for t := range typed {
+		types = append(types, t)
+	}
+	sort.Strings(types) // deterministic SQL for stable plans and tests
+	for _, typ := range types {
+		tP := b.next(typ)
+		idsP := b.next(typed[typ])
+		clauses = append(clauses, fmt.Sprintf("(s.target_type = %s AND s.target_id = ANY(%s))", tP, idsP))
+	}
+	if len(bare) > 0 {
+		idsP := b.next(bare)
+		clauses = append(clauses, fmt.Sprintf("s.target_id = ANY(%s)", idsP))
+	}
+	if len(clauses) == 0 {
+		return "", false
+	}
+	targetClause := clauses[0]
+	if len(clauses) > 1 {
+		targetClause = "(" + strings.Join(clauses, " OR ") + ")"
+	}
+	body := fmt.Sprintf(
+		"SELECT 1 FROM sp_reference s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND %s",
+		rtP, pP, targetClause,
+	)
+	return "EXISTS (" + body + ")", true
 }
 
 // buildExistsForValue builds an EXISTS subquery for a single value, routing to
@@ -1574,6 +1749,10 @@ func (b *queryBuilder) fetchSQL(limit, offset int) string {
 		return b.directDriveSQL(terms, limit, offset)
 	}
 
+	if b.compositeDriveOK(terms) {
+		return b.compositeDriveSQL(terms, limit, offset)
+	}
+
 	// Correlated id-first: compute fhir_id plus each sort key once in the candidate
 	// CTE, carry them through the LIMIT, then re-apply the sort after the json join.
 	selectList := []string{"r.fhir_id"}
@@ -1620,6 +1799,54 @@ func (b *queryBuilder) fetchSQL(limit, offset int) string {
 func (b *queryBuilder) directDrive(terms []orderTerm) bool {
 	return b.numericTable != "" && len(b.numericBodies) > 0 &&
 		b.predicateCount == 1 && orderByResourceIndex(terms)
+}
+
+// compositeDriveOK reports whether a captured composite drive can be used: the
+// composite must be the sole predicate (predicateCount == 1, so its two
+// components fully express the match) and the sort must map to a resources
+// column (applied after the resources join, since the token driver table has no
+// denormalised sort column). Otherwise the search keeps the correlated id-first
+// CTE built from b.where.
+func (b *queryBuilder) compositeDriveOK(terms []orderTerm) bool {
+	return b.comp != nil && b.predicateCount == 1 && orderByResourceIndex(terms)
+}
+
+// compositeDriveSQL resolves candidate resource_ids from the composite's
+// selective token component (the driver), filtered by the other component as a
+// nested EXISTS, then joins resources once for the small candidate set and
+// sorts/limits there. This avoids both the resources recency-walk and the
+// correlated CTE's habit of joining resources for every single-component match
+// before intersecting. The driver/filter bodies reuse the $N args already bound
+// while the components were built; only limit/offset are appended here, and the
+// resources_type placeholder reuses writeBase's $1 (b.rtParam) so no bound
+// parameter is left unreferenced (SQLSTATE 42P18).
+func (b *queryBuilder) compositeDriveSQL(terms []orderTerm, limit, offset int) string {
+	var order []string
+	for _, t := range terms {
+		order = append(order, t.expr+" "+t.dir)
+	}
+	limitP := b.next(limit)
+	offsetP := b.next(offset)
+	return fmt.Sprintf(`
+		WITH candidates AS MATERIALIZED (
+			SELECT s.resource_id AS fhir_id
+			FROM %s s
+			WHERE s.tenant_id = current_setting('app.current_tenant', true) AND %s
+				AND EXISTS (SELECT 1 FROM %s s2 WHERE s2.resource_id = s.resource_id AND %s)
+		)
+		SELECT r.resource_json, r.version_id, r.last_updated
+		FROM (SELECT DISTINCT fhir_id FROM candidates) c
+		JOIN resources r ON r.fhir_id = c.fhir_id
+			AND r.resource_type = %s
+			AND r.tenant_id = current_setting('app.current_tenant', true)
+			AND r.is_deleted = FALSE
+		ORDER BY %s
+		LIMIT %s OFFSET %s`,
+		b.comp.driverTable, b.comp.driverBody,
+		b.comp.filterTable, b.comp.filterBody,
+		b.rtParam,
+		strings.Join(order, ", "), limitP, offsetP,
+	)
 }
 
 // directDriveSQL builds the id-first fetch that resolves candidates directly from

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -276,14 +276,16 @@ type queryBuilder struct {
 	// density probe.
 	numericTable  string
 	numericBodies []string
-	// inComposite is set while buildCompositeExists resolves its component
-	// sub-predicates. A composite embedding a quantity/number component would
-	// otherwise have buildQuantityExists/buildNumberExists capture numericTable/
-	// numericBodies, wrongly triggering the direct-drive fetch — which emits only
-	// that one component's body and drops the rest of the composite (both wrong
-	// results and an orphaned parameter → SQLSTATE 42P18). The capture is skipped
-	// while this is set, so a composite keeps the correlated id-first shape.
-	inComposite bool
+	// suppressDirectDrive is set while a nested value predicate is being built —
+	// a composite component (buildCompositeExists), a chained target
+	// (buildChainedCondition), or a _has value (applyHas). In those contexts the
+	// numeric builders would otherwise capture numericTable/numericBodies, and a
+	// lone such predicate would then wrongly satisfy directDrive() — emitting only
+	// that embedded numeric body and dropping the surrounding structure (wrong
+	// results, plus orphaned params → SQLSTATE 42P18). Capture is skipped while
+	// this is set, so those searches keep the correlated id-first / single-scan
+	// shape built from b.where.
+	suppressDirectDrive bool
 	// err is set when the request can't be satisfied (e.g. a registry-known
 	// param of unsupported type like composite/special). Search() returns it
 	// as an UnsupportedParamError rather than silently widening the result set.
@@ -443,10 +445,15 @@ func (b *queryBuilder) applyHas(modifier, value string) {
 	sourceType, refParam, valueParam := parts[0], parts[1], parts[2]
 
 	// Build the inner predicate for valueParam=value on sourceType, shadowing
-	// the outer 'r' alias with the source resource row.
+	// the outer 'r' alias with the source resource row. suppressDirectDrive so a
+	// numeric valueParam is not mistaken for a direct-drive candidate (this is a
+	// reverse-chained predicate on the source type, not a bare value match).
 	saved := b.rt
 	b.rt = sourceType
+	prevSuppress := b.suppressDirectDrive
+	b.suppressDirectDrive = true
 	inner := b.combinedExists(valueParam, "", value)
+	b.suppressDirectDrive = prevSuppress
 	b.rt = saved
 	if inner == "" {
 		return
@@ -492,14 +499,14 @@ func (b *queryBuilder) buildCompositeExists(def searchparam.Definition, param, v
 
 	// Build the two component SELECT bodies. Each is a fully-formed
 	// "SELECT 1 FROM sp_<type> s WHERE s.resource_id = r.fhir_id AND …"
-	// correlated to the outer resource row. inComposite suppresses the
-	// direct-drive capture for a numeric component: the composite's full
-	// predicate is both components, so it must keep the correlated id-first shape.
-	prevInComposite := b.inComposite
-	b.inComposite = true
+	// correlated to the outer resource row. suppressDirectDrive stops a numeric
+	// component from being captured as a direct-drive candidate: the composite's
+	// full predicate is both components, so it must keep the correlated id-first shape.
+	prev := b.suppressDirectDrive
+	b.suppressDirectDrive = true
 	cond1, ok1 := b.buildExistsForValue(comp1Name, "", val1)
 	cond2, ok2 := b.buildExistsForValue(comp2Name, "", val2)
-	b.inComposite = prevInComposite
+	b.suppressDirectDrive = prev
 	if !ok1 || !ok2 || cond1 == "" || cond2 == "" {
 		return "", false
 	}
@@ -675,9 +682,14 @@ func (b *queryBuilder) buildChainedCondition(sourceType, ref, targetType, target
 	}
 
 	// Leaf hop: build the value predicate on the final target type.
+	// suppressDirectDrive so a numeric targetParam is not captured as a direct-drive
+	// candidate — it is a chained predicate on the target type, not a bare match.
 	saved := b.rt
 	b.rt = targetType
+	prevSuppress := b.suppressDirectDrive
+	b.suppressDirectDrive = true
 	inner := b.combinedExists(targetParam, targetModifier, value)
+	b.suppressDirectDrive = prevSuppress
 	b.rt = saved
 	if inner == "" {
 		return ""
@@ -1077,9 +1089,9 @@ func (b *queryBuilder) buildNumberExists(param, value string) string {
 	}
 	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
 	// Capture the correlation-free body so a lone number predicate can drive the
-	// id-first CTE straight off sp_number (see fetchSQL). Skipped inside a
-	// composite, whose full predicate is more than this one component.
-	if !b.inComposite {
+	// id-first CTE straight off sp_number (see fetchSQL). Skipped inside a nested
+	// context (composite / chained / _has), whose full predicate is more than this.
+	if !b.suppressDirectDrive {
 		b.numericTable = "sp_number"
 		b.numericBodies = append(b.numericBodies, body)
 	}
@@ -1177,9 +1189,9 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	}
 	// Capture the correlation-free body so a lone quantity predicate can drive the
 	// id-first CTE straight off sp_quantity (see fetchSQL). The same $N args are
-	// shared with the EXISTS form below. Skipped inside a composite, whose full
-	// predicate is more than this one component.
-	if !b.inComposite {
+	// shared with the EXISTS form below. Skipped inside a nested context (composite
+	// / chained / _has), whose full predicate is more than this one body.
+	if !b.suppressDirectDrive {
 		b.numericTable = "sp_quantity"
 		b.numericBodies = append(b.numericBodies, body)
 	}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -248,6 +248,12 @@ type queryBuilder struct {
 	args        []any
 	argN        int
 	sort        []sortKey
+	// usesSP is set when a positive value predicate against a large,
+	// selectivity-mis-estimated sp_* table (quantity/number/token/composite; see
+	// paramUsesIdFirst) is added. It selects the id-first fetch strategy in
+	// fetchSQL, which avoids the full-table scan the ordered-scan plan degrades to
+	// for sparse result sets on those tables.
+	usesSP bool
 	// err is set when the request can't be satisfied (e.g. a registry-known
 	// param of unsupported type like composite/special). Search() returns it
 	// as an UnsupportedParamError rather than silently widening the result set.
@@ -380,6 +386,12 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 
 	if expr := b.combinedExists(param, modifier, value); expr != "" {
 		b.and(expr)
+		// Route this search through the id-first fetch strategy only for the
+		// large, selectivity-mis-estimated sp_* tables (see fetchSQL). reference,
+		// date, string and uri params keep the early-terminating ordered scan.
+		if b.paramUsesIdFirst(param) {
+			b.usesSP = true
+		}
 	}
 }
 
@@ -728,6 +740,38 @@ func (b *queryBuilder) buildTypedExists(def searchparam.Definition, param, modif
 		slog.Warn("unsupported search param type; failing request",
 			"resourceType", b.rt, "param", param, "paramType", paramType)
 		return "", false
+	}
+}
+
+// paramUsesIdFirst reports whether a positive value predicate on this search
+// param should select the id-first fetch strategy (see fetchSQL). It is enabled
+// only for the large, selectivity-mis-estimated sp_* tables — quantity, number,
+// token, and composites built from them — where the ordered-scan plan collapses
+// to a full-table scan-with-probe when the result set is sparse or empty (the
+// source of the multi-second query tail on the perf dataset).
+//
+// reference is deliberately excluded: Postgres already plans it id-first from the
+// sp_reference target index, so wrapping it would only add the CTE's fixed cost.
+// date, string and uri live in small tables where even a full scan is cheap, so
+// they keep the early-terminating ordered scan.
+func (b *queryBuilder) paramUsesIdFirst(param string) bool {
+	if pt, ok := universalParamType[param]; ok {
+		return idFirstType(pt)
+	}
+	if b.reg != nil {
+		if def, ok := b.reg.Lookup(b.rt, param); ok {
+			return idFirstType(def.ParamType)
+		}
+	}
+	return false
+}
+
+func idFirstType(paramType string) bool {
+	switch paramType {
+	case "quantity", "number", "token", "composite":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1173,15 +1217,26 @@ func (b *queryBuilder) addSort(value string) {
 	}
 }
 
-// orderByClause builds the SQL ORDER BY body (without the "ORDER BY" keyword)
-// from b.sort. Each search-param key becomes a correlated subquery into its
-// sp_* table — MIN(value) for ascending, MAX(value) for descending — so a
-// resource with multiple values sorts by its lowest/highest, with NULLS LAST
-// so unindexed resources sort to the end. _id and _lastUpdated sort directly
-// off the resources table. Falls back to last_updated DESC when no usable key
-// is supplied.
-func (b *queryBuilder) orderByClause() string {
-	var clauses []string
+// orderTerm is one resolved ORDER BY component: a SQL expression (referencing
+// the resources alias r) and its direction suffix (e.g. "DESC" or
+// "ASC NULLS LAST").
+type orderTerm struct {
+	expr string
+	dir  string
+}
+
+// orderTerms resolves b.sort into structured ORDER BY components. Each
+// search-param key becomes a correlated subquery into its sp_* table — MIN(value)
+// for ascending, MAX(value) for descending — so a resource with multiple values
+// sorts by its lowest/highest, with NULLS LAST so unindexed resources sort to the
+// end. _id and _lastUpdated sort directly off the resources table. Falls back to
+// last_updated DESC when no usable key is supplied.
+//
+// Returning structured terms (rather than a pre-joined string) lets fetch build
+// the id-first query, where the sort keys are computed once in the candidate CTE,
+// carried through the LIMIT, and re-applied after the resource_json join.
+func (b *queryBuilder) orderTerms() []orderTerm {
+	var terms []orderTerm
 	for _, k := range b.sort {
 		dir := "ASC"
 		if k.desc {
@@ -1189,10 +1244,10 @@ func (b *queryBuilder) orderByClause() string {
 		}
 		switch k.param {
 		case "_id":
-			clauses = append(clauses, "r.fhir_id "+dir)
+			terms = append(terms, orderTerm{"r.fhir_id", dir})
 			continue
 		case "_lastUpdated":
-			clauses = append(clauses, "r.last_updated "+dir)
+			terms = append(terms, orderTerm{"r.last_updated", dir})
 			continue
 		case "_score":
 			// relevance scoring is not implemented; skip rather than error.
@@ -1220,12 +1275,12 @@ func (b *queryBuilder) orderByClause() string {
 			"(SELECT %s(s.%s) FROM %s s WHERE s.resource_id = r.fhir_id AND s.resource_type = r.resource_type AND s.param_name = %s)",
 			agg, col, table, pP,
 		)
-		clauses = append(clauses, expr+" "+dir+" NULLS LAST")
+		terms = append(terms, orderTerm{expr, dir + " NULLS LAST"})
 	}
-	if len(clauses) == 0 {
-		return "r.last_updated DESC"
+	if len(terms) == 0 {
+		return []orderTerm{{"r.last_updated", "DESC"}}
 	}
-	return strings.Join(clauses, ", ")
+	return terms
 }
 
 // sortColumnForTable returns the value column to sort on for a given sp_* table.
@@ -1350,19 +1405,7 @@ func (s *Store) LastN(ctx context.Context, params map[string][]string, maxN int)
 }
 
 func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset int) ([]map[string]any, error) {
-	// Build the ORDER BY before binding LIMIT/OFFSET so the positional args line
-	// up: [where args…, order-by param args…, limit, offset].
-	orderBy := b.orderByClause()
-	limitP := b.next(limit)
-	offsetP := b.next(offset)
-	q := fmt.Sprintf(`
-		SELECT r.resource_json, r.version_id, r.last_updated
-		FROM resources r
-		WHERE %s
-		ORDER BY %s
-		LIMIT %s OFFSET %s`,
-		b.where.String(), orderBy, limitP, offsetP,
-	)
+	q := b.fetchSQL(limit, offset)
 
 	rows, err := pool.Query(ctx, q, b.args...)
 	if err != nil {
@@ -1385,6 +1428,87 @@ func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset in
 		entries = append(entries, m)
 	}
 	return entries, rows.Err()
+}
+
+// fetchSQL builds the paginated result query. It binds the ORDER BY parameters
+// (for _sort on search params) before LIMIT/OFFSET, keeping b.args ordered as
+// [where args…, order-by args…, limit, offset, …].
+//
+// Two query shapes are produced:
+//
+//   - No sp_* predicate (plain browse, or filters only on resources columns such
+//     as _id / _lastUpdated / _text): the classic single-scan form. With
+//     ORDER BY r.last_updated served directly by idx_res_active, the LIMIT
+//     terminates early after `limit` rows without visiting the whole match set.
+//
+//   - With an sp_* predicate: an id-first form. A MATERIALIZED CTE resolves the
+//     matching (fhir_id, sort keys) first, so the planner can drive the match off
+//     the selective sp_* index instead of scanning resources in last_updated
+//     order and probing sp_* once per candidate row. The sort + LIMIT then run
+//     over the light candidate rows, and only the surviving page joins back to
+//     resources for resource_json.
+//
+// The MATERIALIZED barrier is load-bearing: without it the planner collapses the
+// id-first form back into the single-scan shape, whose cost explodes for
+// selective search predicates — a full resources scan with a per-row sp_* probe
+// that never reaches the LIMIT (observed at multiple seconds per query, versus
+// sub-second id-first, on the perf dataset). The barrier gives up the single-scan
+// early-termination for broad (non-selective) sp_* predicates, so it is applied
+// only when the WHERE actually filters on an sp_* table.
+func (b *queryBuilder) fetchSQL(limit, offset int) string {
+	terms := b.orderTerms()
+
+	if !b.usesSP {
+		var clauses []string
+		for _, t := range terms {
+			clauses = append(clauses, t.expr+" "+t.dir)
+		}
+		limitP := b.next(limit)
+		offsetP := b.next(offset)
+		return fmt.Sprintf(`
+		SELECT r.resource_json, r.version_id, r.last_updated
+		FROM resources r
+		WHERE %s
+		ORDER BY %s
+		LIMIT %s OFFSET %s`,
+			b.where.String(), strings.Join(clauses, ", "), limitP, offsetP,
+		)
+	}
+
+	// id-first: compute fhir_id plus each sort key once in the candidate CTE,
+	// carry them through the LIMIT, then re-apply the sort after the json join.
+	selectList := []string{"r.fhir_id"}
+	innerCols := []string{"fhir_id"}
+	var innerOrder, outerOrder []string
+	for i, t := range terms {
+		alias := fmt.Sprintf("sort%d", i)
+		selectList = append(selectList, t.expr+" AS "+alias)
+		innerCols = append(innerCols, alias)
+		innerOrder = append(innerOrder, alias+" "+t.dir)
+		outerOrder = append(outerOrder, "c."+alias+" "+t.dir)
+	}
+	limitP := b.next(limit)
+	offsetP := b.next(offset)
+	rtP := b.next(b.rt)
+
+	return fmt.Sprintf(`
+		WITH candidates AS MATERIALIZED (
+			SELECT %s
+			FROM resources r
+			WHERE %s
+		)
+		SELECT r.resource_json, r.version_id, r.last_updated
+		FROM (SELECT %s FROM candidates ORDER BY %s LIMIT %s OFFSET %s) c
+		JOIN resources r ON r.fhir_id = c.fhir_id
+			AND r.resource_type = %s
+			AND r.tenant_id = current_setting('app.current_tenant', true)
+		ORDER BY %s`,
+		strings.Join(selectList, ", "),
+		b.where.String(),
+		strings.Join(innerCols, ", "), strings.Join(innerOrder, ", "), limitP, offsetP,
+		rtP,
+		strings.Join(outerOrder, ", "),
+	)
 }
 
 // fetchWithCount returns the page of matching rows plus the exact total match

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1616,12 +1616,10 @@ func (b *queryBuilder) directDrive(terms []orderTerm) bool {
 // building; only limit/offset/rt are appended here.
 func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) string {
 	selectList := []string{"s.resource_id AS fhir_id"}
-	innerCols := []string{"fhir_id"}
 	var innerOrder, outerOrder []string
 	for i, t := range terms {
 		alias := fmt.Sprintf("sort%d", i)
 		selectList = append(selectList, directDriveSortExpr(t.expr)+" AS "+alias)
-		innerCols = append(innerCols, alias)
 		innerOrder = append(innerOrder, alias+" "+t.dir)
 		outerOrder = append(outerOrder, "c."+alias+" "+t.dir)
 	}
@@ -1631,18 +1629,32 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 	}
 	limitP := b.next(limit)
 	offsetP := b.next(offset)
-	// Reuse writeBase's resource_type placeholder ($1) rather than binding a fresh
-	// one: b.where is not emitted by this shape, so $1 would otherwise be an unused
-	// parameter and Postgres could not infer its type (SQLSTATE 42P18).
 
+	// Early-exit id-first fetch. DISTINCT + ORDER BY + LIMIT are pushed into the
+	// candidate subquery (no MATERIALIZED barrier) so the planner drives it
+	// straight off an sp_* index and stops as soon as `limit` distinct resources
+	// are found:
+	//
+	//   - dense predicate sorted by last_updated → recency covering index
+	//     (…, last_updated DESC) INCLUDE (value_low, …): the page resolves after
+	//     scanning a few dozen index rows, instead of the older MATERIALIZED CTE's
+	//     full materialise-and-sort of the whole match set (e.g. value-quantity=le140
+	//     matched ~500k rows → multi-hundred-ms sort; now ~1ms early-exit).
+	//   - sparse/empty predicate → value index: returns few/zero rows directly,
+	//     never a resources full-scan.
+	//
+	// DISTINCT dedupes resources that have several matching sp_* rows so a page is
+	// always `limit` distinct resources (the old shape could emit duplicates).
+	// Reuse writeBase's resource_type placeholder (b.rtParam): b.where is not
+	// emitted by this shape, so binding a fresh one would orphan $1 (SQLSTATE 42P18).
 	return fmt.Sprintf(`
-		WITH candidates AS MATERIALIZED (
-			SELECT %s
+		SELECT r.resource_json, r.version_id, r.last_updated
+		FROM (
+			SELECT DISTINCT %s
 			FROM %s s
 			WHERE s.tenant_id = current_setting('app.current_tenant', true) AND %s
-		)
-		SELECT r.resource_json, r.version_id, r.last_updated
-		FROM (SELECT %s FROM candidates ORDER BY %s LIMIT %s OFFSET %s) c
+			ORDER BY %s LIMIT %s OFFSET %s
+		) c
 		JOIN resources r ON r.fhir_id = c.fhir_id
 			AND r.resource_type = %s
 			AND r.tenant_id = current_setting('app.current_tenant', true)
@@ -1650,7 +1662,7 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 		ORDER BY %s`,
 		strings.Join(selectList, ", "),
 		b.numericTable, match,
-		strings.Join(innerCols, ", "), strings.Join(innerOrder, ", "), limitP, offsetP,
+		strings.Join(innerOrder, ", "), limitP, offsetP,
 		b.rtParam,
 		strings.Join(outerOrder, ", "),
 	)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -247,7 +247,13 @@ type queryBuilder struct {
 	where       strings.Builder
 	args        []any
 	argN        int
-	sort        []sortKey
+	// rtParam is the placeholder writeBase bound for the resource_type ($1). The
+	// direct-drive fetch reuses it in its resources JOIN so that placeholder stays
+	// referenced — a parameter bound but never used trips Postgres' type inference
+	// (SQLSTATE 42P18), which the direct-drive shape would otherwise hit because it
+	// builds its WHERE from numericBodies rather than b.where.
+	rtParam string
+	sort    []sortKey
 	// usesSP is set when a positive value predicate against a numeric,
 	// selectivity-mis-estimated sp_* table (quantity/number, or composite which
 	// embeds one; see paramUsesIdFirst) is added. It selects the id-first fetch
@@ -291,6 +297,7 @@ func (b *queryBuilder) next(v any) string {
 
 func (b *queryBuilder) writeBase() {
 	rtP := b.next(b.rt)
+	b.rtParam = rtP
 	// Tenant scope (defence in depth alongside Row-Level Security): restrict to
 	// the request's tenant via the app.current_tenant setting the store applies
 	// to the connection/transaction. Holds even if the DB role bypasses RLS.
@@ -1518,7 +1525,7 @@ func (b *queryBuilder) fetchSQL(limit, offset int) string {
 		)
 	}
 
-	if b.directDrive() {
+	if b.directDrive(terms) {
 		return b.directDriveSQL(terms, limit, offset)
 	}
 
@@ -1565,9 +1572,9 @@ func (b *queryBuilder) fetchSQL(limit, offset int) string {
 // scan; predicateCount == 1 guarantees the bodies fully express the match (no
 // other WHERE predicate); orderByResourceIndex keeps the sort mappable to the
 // sp_* columns (last_updated / resource_id).
-func (b *queryBuilder) directDrive() bool {
+func (b *queryBuilder) directDrive(terms []orderTerm) bool {
 	return b.numericTable != "" && len(b.numericBodies) > 0 &&
-		b.predicateCount == 1 && b.orderByResourceIndex()
+		b.predicateCount == 1 && orderByResourceIndex(terms)
 }
 
 // directDriveSQL builds the id-first fetch that resolves candidates directly from
@@ -1593,7 +1600,9 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 	}
 	limitP := b.next(limit)
 	offsetP := b.next(offset)
-	rtP := b.next(b.rt)
+	// Reuse writeBase's resource_type placeholder ($1) rather than binding a fresh
+	// one: b.where is not emitted by this shape, so $1 would otherwise be an unused
+	// parameter and Postgres could not infer its type (SQLSTATE 42P18).
 
 	return fmt.Sprintf(`
 		WITH candidates AS MATERIALIZED (
@@ -1611,7 +1620,7 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 		strings.Join(selectList, ", "),
 		b.numericTable, match,
 		strings.Join(innerCols, ", "), strings.Join(innerOrder, ", "), limitP, offsetP,
-		rtP,
+		b.rtParam,
 		strings.Join(outerOrder, ", "),
 	)
 }
@@ -1631,12 +1640,14 @@ func directDriveSortExpr(resExpr string) string {
 }
 
 // orderByResourceIndex reports whether every ORDER BY term is a plain resources
-// column (last_updated / fhir_id), so the ordered single-scan fetch can serve the
-// sort straight from idx_res_active and stop at the page. A _sort on an sp_* param
-// orders by a correlated subquery that no index provides, so the ordered scan
-// could not early-terminate and the id-first form must be kept.
-func (b *queryBuilder) orderByResourceIndex() bool {
-	for _, t := range b.orderTerms() {
+// column (last_updated / fhir_id), so the sort maps onto the sp_* value index's
+// denormalised columns (direct-drive). A _sort on an sp_* param orders by a
+// correlated subquery that no such index provides, so it keeps the correlated
+// id-first shape. It takes the already-resolved terms rather than calling
+// orderTerms() itself: orderTerms binds a $N arg per _sort param, so calling it
+// twice would orphan a placeholder (SQLSTATE 42P18).
+func orderByResourceIndex(terms []orderTerm) bool {
+	for _, t := range terms {
 		if t.expr != "r.last_updated" && t.expr != "r.fhir_id" {
 			return false
 		}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -248,12 +248,20 @@ type queryBuilder struct {
 	args        []any
 	argN        int
 	sort        []sortKey
-	// usesSP is set when a positive value predicate against a large,
-	// selectivity-mis-estimated sp_* table (quantity/number/token/composite; see
-	// paramUsesIdFirst) is added. It selects the id-first fetch strategy in
-	// fetchSQL, which avoids the full-table scan the ordered-scan plan degrades to
-	// for sparse result sets on those tables.
+	// usesSP is set when a positive value predicate against a numeric,
+	// selectivity-mis-estimated sp_* table (quantity/number, or composite which
+	// embeds one; see paramUsesIdFirst) is added. It selects the id-first fetch
+	// strategy in fetchSQL, which avoids the full-table scan the ordered-scan plan
+	// degrades to for sparse result sets on those tables.
 	usesSP bool
+	// predicateCount counts the top-level value predicates added (one per and()).
+	// numericSP is set when a quantity/number param is added. Together they gate
+	// the dense probe (see probeDense): it runs only for a search whose sole
+	// predicate is numeric, where the LIMIT-bounded probe is cheap. A token or
+	// composite predicate would make the probe scan a large match set, so those
+	// (and any multi-predicate search) keep the id-first shape unconditionally.
+	predicateCount int
+	numericSP      bool
 	// err is set when the request can't be satisfied (e.g. a registry-known
 	// param of unsupported type like composite/special). Search() returns it
 	// as an UnsupportedParamError rather than silently widening the result set.
@@ -286,6 +294,7 @@ func (b *queryBuilder) writeBase() {
 func (b *queryBuilder) and(cond string) {
 	b.where.WriteString(" AND ")
 	b.where.WriteString(cond)
+	b.predicateCount++
 }
 
 func (b *queryBuilder) applyParam(rawKey, value string) {
@@ -393,6 +402,9 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 		// planner has good enough statistics to pick the right plan itself.
 		if b.paramUsesIdFirst(param) {
 			b.usesSP = true
+		}
+		if b.paramIsNumeric(param) {
+			b.numericSP = true
 		}
 	}
 }
@@ -766,6 +778,23 @@ func (b *queryBuilder) paramUsesIdFirst(param string) bool {
 		}
 	}
 	return false
+}
+
+// paramIsNumeric reports whether param maps to a bare numeric sp_* table
+// (quantity/number). These are exactly the predicates whose selectivity the
+// dense probe can measure cheaply via a LIMIT-bounded index scan, so probeDense
+// only engages for a search whose sole predicate is one of them. composite is
+// excluded: it embeds a token whose match set the probe would have to scan.
+func (b *queryBuilder) paramIsNumeric(param string) bool {
+	pt := ""
+	if t, ok := universalParamType[param]; ok {
+		pt = t
+	} else if b.reg != nil {
+		if def, ok := b.reg.Lookup(b.rt, param); ok {
+			pt = def.ParamType
+		}
+	}
+	return pt == "quantity" || pt == "number"
 }
 
 func idFirstType(paramType string) bool {
@@ -1416,7 +1445,11 @@ func (s *Store) LastN(ctx context.Context, params map[string][]string, maxN int)
 }
 
 func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset int) ([]map[string]any, error) {
-	q := b.fetchSQL(limit, offset)
+	dense, err := b.probeDense(ctx, pool)
+	if err != nil {
+		return nil, err
+	}
+	q := b.fetchSQL(limit, offset, dense)
 
 	rows, err := pool.Query(ctx, q, b.args...)
 	if err != nil {
@@ -1447,29 +1480,32 @@ func (b *queryBuilder) fetch(ctx context.Context, pool querier, limit, offset in
 //
 // Two query shapes are produced:
 //
-//   - No sp_* predicate (plain browse, or filters only on resources columns such
-//     as _id / _lastUpdated / _text): the classic single-scan form. With
-//     ORDER BY r.last_updated served directly by idx_res_active, the LIMIT
-//     terminates early after `limit` rows without visiting the whole match set.
+//   - Single-scan form (no numeric sp_* predicate, or dense == true): ORDER BY
+//     r.last_updated served directly by idx_res_active, so the LIMIT terminates
+//     early after `limit` rows without visiting the whole match set. Used for
+//     plain browse, resources-column filters, token/reference/etc. predicates
+//     (the planner picks the right plan from their statistics), and numeric
+//     predicates the probe has confirmed are dense.
 //
-//   - With an sp_* predicate: an id-first form. A MATERIALIZED CTE resolves the
-//     matching (fhir_id, sort keys) first, so the planner can drive the match off
-//     the selective sp_* index instead of scanning resources in last_updated
-//     order and probing sp_* once per candidate row. The sort + LIMIT then run
-//     over the light candidate rows, and only the surviving page joins back to
-//     resources for resource_json.
+//   - id-first form (numeric sp_* predicate, dense == false): a MATERIALIZED CTE
+//     resolves the matching (fhir_id, sort keys) first, so the planner drives the
+//     match off the selective sp_* index instead of scanning resources in
+//     last_updated order and probing sp_* per candidate row. The sort + LIMIT run
+//     over the light candidate rows, then the surviving page joins back for
+//     resource_json.
 //
-// The MATERIALIZED barrier is load-bearing: without it the planner collapses the
-// id-first form back into the single-scan shape, whose cost explodes for
-// selective search predicates — a full resources scan with a per-row sp_* probe
-// that never reaches the LIMIT (observed at multiple seconds per query, versus
-// sub-second id-first, on the perf dataset). The barrier gives up the single-scan
-// early-termination for broad (non-selective) sp_* predicates, so it is applied
-// only when the WHERE actually filters on an sp_* table.
-func (b *queryBuilder) fetchSQL(limit, offset int) string {
+// The MATERIALIZED barrier is load-bearing for a sparse numeric predicate:
+// without it the planner (which cannot estimate an unbounded numeric range)
+// collapses into the single-scan shape and does a full resources scan with a
+// per-row sp_* probe that never reaches the LIMIT — multiple seconds per query on
+// the perf dataset. For a dense numeric predicate that same single-scan shape is
+// instead the fast plan (a page's worth of matches sits in the first handful of
+// rows), so probeDense measures the density up front and passes dense=true to
+// switch back to it.
+func (b *queryBuilder) fetchSQL(limit, offset int, dense bool) string {
 	terms := b.orderTerms()
 
-	if !b.usesSP {
+	if !b.usesSP || dense {
 		var clauses []string
 		for _, t := range terms {
 			clauses = append(clauses, t.expr+" "+t.dir)
@@ -1520,6 +1556,57 @@ func (b *queryBuilder) fetchSQL(limit, offset int) string {
 		rtP,
 		strings.Join(outerOrder, ", "),
 	)
+}
+
+// denseCandidateThreshold is the match-set size at which the single-scan fetch
+// overtakes the id-first MATERIALIZED fetch for a numeric predicate. Below it the
+// id-first form resolves and sorts a small candidate set cheaply; above it that
+// set is large, and materializing+sorting all of it costs more than letting the
+// ordered scan walk idx_res_active and stop at the page. Measured crossover was
+// ~1.5k rows on the perf dataset; 1000 is a slightly conservative round value.
+const denseCandidateThreshold = 1000
+
+// probeDense reports whether a numeric search's match set is large enough that
+// fetchSQL should use the ordered single-scan shape instead of the id-first
+// MATERIALIZED one.
+//
+// It runs only for a search whose sole predicate is numeric (quantity/number)
+// and whose sort is served by the resources index (see orderByResourceIndex).
+// That restriction keeps the check cheap: the LIMIT-bounded probe resolves off
+// the numeric sp_* index — a sparse predicate returns in well under a
+// millisecond, a dense one hits the LIMIT after scanning few rows. token and
+// composite predicates are excluded because their probe would scan a large token
+// match set (and composites are almost always sparse anyway); multi-predicate
+// searches are excluded because the extra predicates make the probe expensive.
+// It reuses b.args as-is (the LIMIT is a constant), so it must run before
+// fetchSQL appends the ORDER BY / LIMIT / OFFSET parameters.
+func (b *queryBuilder) probeDense(ctx context.Context, pool querier) (bool, error) {
+	if !b.numericSP || b.predicateCount != 1 || !b.orderByResourceIndex() {
+		return false, nil
+	}
+	q := fmt.Sprintf(
+		`SELECT count(*) FROM (SELECT 1 FROM resources r WHERE %s LIMIT %d) probe`,
+		b.where.String(), denseCandidateThreshold,
+	)
+	var n int
+	if err := pool.QueryRow(ctx, q, b.args...).Scan(&n); err != nil {
+		return false, err
+	}
+	return n >= denseCandidateThreshold, nil
+}
+
+// orderByResourceIndex reports whether every ORDER BY term is a plain resources
+// column (last_updated / fhir_id), so the ordered single-scan fetch can serve the
+// sort straight from idx_res_active and stop at the page. A _sort on an sp_* param
+// orders by a correlated subquery that no index provides, so the ordered scan
+// could not early-terminate and the id-first form must be kept.
+func (b *queryBuilder) orderByResourceIndex() bool {
+	for _, t := range b.orderTerms() {
+		if t.expr != "r.last_updated" && t.expr != "r.fhir_id" {
+			return false
+		}
+	}
+	return true
 }
 
 // fetchWithCount returns the page of matching rows plus the exact total match

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1821,31 +1821,50 @@ func (b *queryBuilder) compositeDriveOK(terms []orderTerm) bool {
 // resources_type placeholder reuses writeBase's $1 (b.rtParam) so no bound
 // parameter is left unreferenced (SQLSTATE 42P18).
 func (b *queryBuilder) compositeDriveSQL(terms []orderTerm, limit, offset int) string {
-	var order []string
-	for _, t := range terms {
-		order = append(order, t.expr+" "+t.dir)
+	selectList := []string{"s.resource_id AS fhir_id"}
+	var innerOrder, outerOrder []string
+	for i, t := range terms {
+		alias := fmt.Sprintf("sort%d", i)
+		selectList = append(selectList, directDriveSortExpr(t.expr)+" AS "+alias)
+		innerOrder = append(innerOrder, alias+" "+t.dir)
+		outerOrder = append(outerOrder, "c."+alias+" "+t.dir)
 	}
 	limitP := b.next(limit)
 	offsetP := b.next(offset)
+
+	// Early-exit composite drive. DISTINCT + ORDER BY + LIMIT are pushed into the
+	// candidate subquery (no MATERIALIZED barrier) so the planner walks the
+	// driver's recency index (idx_sp_tok_recent: …, code, last_updated DESC)
+	// newest-first for the token component, probes the other component via EXISTS
+	// per row, and stops as soon as `limit` distinct resources are found — instead
+	// of resolving the whole intersection and top-N sorting it (which, for a common
+	// code with a loose value bound, was a multi-second materialise-and-sort plus a
+	// parallel hash join). The sort keys map from their resources columns to the
+	// denormalised sp_token columns (r.last_updated → s.last_updated, r.fhir_id →
+	// s.resource_id). DISTINCT dedupes a resource that carries the code more than
+	// once. Driver/filter bodies reuse the $N args bound while the components were
+	// built; the resource_type placeholder reuses writeBase's $1 (b.rtParam) so no
+	// bound parameter is left unreferenced (SQLSTATE 42P18).
 	return fmt.Sprintf(`
-		WITH candidates AS MATERIALIZED (
-			SELECT s.resource_id AS fhir_id
+		SELECT r.resource_json, r.version_id, r.last_updated
+		FROM (
+			SELECT DISTINCT %s
 			FROM %s s
 			WHERE s.tenant_id = current_setting('app.current_tenant', true) AND %s
 				AND EXISTS (SELECT 1 FROM %s s2 WHERE s2.resource_id = s.resource_id AND %s)
-		)
-		SELECT r.resource_json, r.version_id, r.last_updated
-		FROM (SELECT DISTINCT fhir_id FROM candidates) c
+			ORDER BY %s LIMIT %s OFFSET %s
+		) c
 		JOIN resources r ON r.fhir_id = c.fhir_id
 			AND r.resource_type = %s
 			AND r.tenant_id = current_setting('app.current_tenant', true)
 			AND r.is_deleted = FALSE
-		ORDER BY %s
-		LIMIT %s OFFSET %s`,
+		ORDER BY %s`,
+		strings.Join(selectList, ", "),
 		b.comp.driverTable, b.comp.driverBody,
 		b.comp.filterTable, b.comp.filterBody,
+		strings.Join(innerOrder, ", "), limitP, offsetP,
 		b.rtParam,
-		strings.Join(order, ", "), limitP, offsetP,
+		strings.Join(outerOrder, ", "),
 	)
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -405,14 +405,27 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 
 	// :not negates the match. :not-in is also negated (handled in buildTypedExists
 	// but needs to be NOT EXISTS at the applyParam level).
+	// suppressDirectDrive around the negated branches: a :not / :not-in predicate
+	// is a NOT EXISTS over the positive body, not a bare value match, so the inner
+	// numeric builder must not register it as a direct-drive candidate (which would
+	// let a lone negated numeric search drive the id-first fetch off the *positive*
+	// predicate). Mirrors applyHas / buildCompositeExists / buildChainedCondition.
 	if modifier == "not" {
-		if expr := b.combinedExists(param, "", value); expr != "" {
+		prev := b.suppressDirectDrive
+		b.suppressDirectDrive = true
+		expr := b.combinedExists(param, "", value)
+		b.suppressDirectDrive = prev
+		if expr != "" {
 			b.and("NOT " + expr)
 		}
 		return
 	}
 	if modifier == "not-in" {
-		if expr := b.combinedExists(param, "not-in", value); expr != "" {
+		prev := b.suppressDirectDrive
+		b.suppressDirectDrive = true
+		expr := b.combinedExists(param, "not-in", value)
+		b.suppressDirectDrive = prev
+		if expr != "" {
 			b.and("NOT " + expr)
 		}
 		return
@@ -796,15 +809,16 @@ func (b *queryBuilder) buildTypedExists(def searchparam.Definition, param, modif
 
 // paramUsesIdFirst reports whether a positive value predicate on this search
 // param should select the id-first fetch strategy (see fetchSQL). It is enabled
-// only for the large, selectivity-mis-estimated sp_* tables — quantity, number,
-// token, and composites built from them — where the ordered-scan plan collapses
-// to a full-table scan-with-probe when the result set is sparse or empty (the
-// source of the multi-second query tail on the perf dataset).
+// only for the numeric, selectivity-mis-estimated params — quantity, number, and
+// composites built from them (see idFirstType) — where the ordered-scan plan
+// collapses to a full-table scan-with-probe when the result set is sparse or
+// empty (the source of the multi-second query tail on the perf dataset).
 //
-// reference is deliberately excluded: Postgres already plans it id-first from the
-// sp_reference target index, so wrapping it would only add the CTE's fixed cost.
-// date, string and uri live in small tables where even a full scan is cheap, so
-// they keep the early-terminating ordered scan.
+// token is deliberately excluded (idFirstType): its equality has reliable MCV
+// stats, so the planner already resolves id-first for selective/empty codes and
+// takes the ordered early-exit for dense ones. reference is excluded too —
+// Postgres already plans it id-first from the sp_reference target index — as are
+// date, string and uri, which live in small tables where a full scan is cheap.
 func (b *queryBuilder) paramUsesIdFirst(param string) bool {
 	if pt, ok := universalParamType[param]; ok {
 		return idFirstType(pt)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -276,6 +276,14 @@ type queryBuilder struct {
 	// density probe.
 	numericTable  string
 	numericBodies []string
+	// inComposite is set while buildCompositeExists resolves its component
+	// sub-predicates. A composite embedding a quantity/number component would
+	// otherwise have buildQuantityExists/buildNumberExists capture numericTable/
+	// numericBodies, wrongly triggering the direct-drive fetch — which emits only
+	// that one component's body and drops the rest of the composite (both wrong
+	// results and an orphaned parameter → SQLSTATE 42P18). The capture is skipped
+	// while this is set, so a composite keeps the correlated id-first shape.
+	inComposite bool
 	// err is set when the request can't be satisfied (e.g. a registry-known
 	// param of unsupported type like composite/special). Search() returns it
 	// as an UnsupportedParamError rather than silently widening the result set.
@@ -484,9 +492,14 @@ func (b *queryBuilder) buildCompositeExists(def searchparam.Definition, param, v
 
 	// Build the two component SELECT bodies. Each is a fully-formed
 	// "SELECT 1 FROM sp_<type> s WHERE s.resource_id = r.fhir_id AND …"
-	// correlated to the outer resource row.
+	// correlated to the outer resource row. inComposite suppresses the
+	// direct-drive capture for a numeric component: the composite's full
+	// predicate is both components, so it must keep the correlated id-first shape.
+	prevInComposite := b.inComposite
+	b.inComposite = true
 	cond1, ok1 := b.buildExistsForValue(comp1Name, "", val1)
 	cond2, ok2 := b.buildExistsForValue(comp2Name, "", val2)
+	b.inComposite = prevInComposite
 	if !ok1 || !ok2 || cond1 == "" || cond2 == "" {
 		return "", false
 	}
@@ -1064,9 +1077,12 @@ func (b *queryBuilder) buildNumberExists(param, value string) string {
 	}
 	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
 	// Capture the correlation-free body so a lone number predicate can drive the
-	// id-first CTE straight off sp_number (see fetchSQL).
-	b.numericTable = "sp_number"
-	b.numericBodies = append(b.numericBodies, body)
+	// id-first CTE straight off sp_number (see fetchSQL). Skipped inside a
+	// composite, whose full predicate is more than this one component.
+	if !b.inComposite {
+		b.numericTable = "sp_number"
+		b.numericBodies = append(b.numericBodies, body)
+	}
 	return "SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND " + body
 }
 
@@ -1161,9 +1177,12 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	}
 	// Capture the correlation-free body so a lone quantity predicate can drive the
 	// id-first CTE straight off sp_quantity (see fetchSQL). The same $N args are
-	// shared with the EXISTS form below.
-	b.numericTable = "sp_quantity"
-	b.numericBodies = append(b.numericBodies, body)
+	// shared with the EXISTS form below. Skipped inside a composite, whose full
+	// predicate is more than this one component.
+	if !b.inComposite {
+		b.numericTable = "sp_quantity"
+		b.numericBodies = append(b.numericBodies, body)
+	}
 	return "SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND " + body
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -387,8 +387,10 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 	if expr := b.combinedExists(param, modifier, value); expr != "" {
 		b.and(expr)
 		// Route this search through the id-first fetch strategy only for the
-		// large, selectivity-mis-estimated sp_* tables (see fetchSQL). reference,
-		// date, string and uri params keep the early-terminating ordered scan.
+		// numeric sp_* predicates the planner mis-estimates (quantity/number, and
+		// composite which embeds one — see idFirstType). token, reference, date,
+		// string and uri params keep the early-terminating ordered scan, where the
+		// planner has good enough statistics to pick the right plan itself.
 		if b.paramUsesIdFirst(param) {
 			b.usesSP = true
 		}
@@ -768,7 +770,16 @@ func (b *queryBuilder) paramUsesIdFirst(param string) bool {
 
 func idFirstType(paramType string) bool {
 	switch paramType {
-	case "quantity", "number", "token", "composite":
+	// quantity/number range predicates (and composite, which embeds one) are
+	// mis-estimated by the planner — it cannot judge the selectivity of an
+	// unbounded numeric range, so without the id-first barrier it may choose the
+	// ordered scan and walk the whole table for a sparse match set. token is
+	// deliberately NOT here: token equality has reliable MCV statistics, so the
+	// planner already resolves id-first for selective/empty codes and takes the
+	// ordered early-exit for dense ones. Forcing id-first on tokens instead
+	// pessimises the common dense case (e.g. a category code matching most rows),
+	// which then has to materialize and sort the entire match set.
+	case "quantity", "number", "composite":
 		return true
 	default:
 		return false

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -252,7 +252,7 @@ type queryBuilder struct {
 	// direct-drive fetch reuses it in its resources JOIN so that placeholder stays
 	// referenced — a parameter bound but never used trips Postgres' type inference
 	// (SQLSTATE 42P18), which the direct-drive shape would otherwise hit because it
-	// builds its WHERE from numericBodies rather than b.where.
+	// builds its WHERE from driveBodies rather than b.where.
 	rtParam string
 	sort    []sortKey
 	// usesSP is set when a positive value predicate against a numeric,
@@ -262,21 +262,22 @@ type queryBuilder struct {
 	// degrades to for sparse result sets on those tables.
 	usesSP bool
 	// predicateCount counts the top-level value predicates added (one per and()).
-	// With numericTable/numericBodies it gates the direct-drive id-first fetch (see
+	// With driveTable/driveBodies it gates the direct-drive id-first fetch (see
 	// fetchSQL): a search whose sole predicate (predicateCount == 1) is a numeric
 	// value match can drive the candidate CTE straight off the sp_* value index.
 	predicateCount int
-	// numericTable / numericBodies capture the non-correlated candidate source for
-	// a numeric (quantity/number) predicate — the sp_* table and the predicate on
-	// alias s with the s.resource_id = r.fhir_id correlation stripped (comma-OR
-	// values append one body each). When the search turns out to be a lone numeric
-	// predicate sorted by a resources column, fetchSQL drives the id-first CTE off
-	// these instead of scanning resources with a correlated EXISTS. Since sp_* rows
-	// carry a denormalised last_updated in the covering index, both the sparse and
-	// the dense case resolve index-only — no per-match resources lookup, and no
-	// density probe.
-	numericTable  string
-	numericBodies []string
+	// driveTable / driveBodies capture the non-correlated candidate source for a
+	// drivable predicate — a numeric (quantity/number) value match or a code-token
+	// match — as the sp_* table plus the predicate on alias s with the
+	// s.resource_id = r.fhir_id correlation stripped (comma-OR values append one
+	// body each). When the search is a lone such predicate sorted by a resources
+	// column, fetchSQL drives the candidate resolve straight off that table's
+	// recency index (idx_sp_qty_recent / idx_sp_num_recent / idx_sp_tok_recent),
+	// newest-first with the sort key from the denormalised last_updated, instead of
+	// walking resources with a correlated EXISTS. Both the sparse and dense case
+	// early-exit index-only — no per-match resources lookup.
+	driveTable  string
+	driveBodies []string
 	// comp captures a composite search (e.g. code-value-quantity) as a two-table
 	// drive: resolve candidate resource_ids from the selective token component's
 	// sp_* table, filtered by the other component as a nested EXISTS, before
@@ -289,7 +290,7 @@ type queryBuilder struct {
 	// suppressDirectDrive is set while a nested value predicate is being built —
 	// a composite component (buildCompositeExists), a chained target
 	// (buildChainedCondition), or a _has value (applyHas). In those contexts the
-	// numeric builders would otherwise capture numericTable/numericBodies, and a
+	// numeric builders would otherwise capture driveTable/driveBodies, and a
 	// lone such predicate would then wrongly satisfy directDrive() — emitting only
 	// that embedded numeric body and dropping the surrounding structure (wrong
 	// results, plus orphaned params → SQLSTATE 42P18). Capture is skipped while
@@ -443,12 +444,17 @@ func (b *queryBuilder) applySearchParam(param, modifier, value string) {
 
 	if expr := b.combinedExists(param, modifier, value); expr != "" {
 		b.and(expr)
-		// Route this search through the id-first fetch strategy only for the
-		// numeric sp_* predicates the planner mis-estimates (quantity/number, and
-		// composite which embeds one — see idFirstType). token, reference, date,
-		// string and uri params keep the early-terminating ordered scan, where the
-		// planner has good enough statistics to pick the right plan itself.
-		if b.paramUsesIdFirst(param) {
+		// Route this search through the id-first fetch strategy when it can be
+		// resolved off an sp_* recency index instead of the resources
+		// recency-walk. Two triggers:
+		//   - paramUsesIdFirst: quantity/number/composite, which the planner
+		//     mis-estimates for an unbounded numeric range (see idFirstType).
+		//   - a captured drive candidate (b.driveTable): a lone code-token search,
+		//     which the planner otherwise resolves by walking resources and probing
+		//     sp_token per row rather than driving from idx_sp_tok_recent.
+		// reference, date, string, uri and system-only / :text tokens capture no
+		// drive candidate and keep the early-terminating ordered scan.
+		if b.paramUsesIdFirst(param) || b.driveTable != "" {
 			b.usesSP = true
 		}
 	}
@@ -1011,12 +1017,17 @@ func idFirstType(paramType string) bool {
 	// quantity/number range predicates (and composite, which embeds one) are
 	// mis-estimated by the planner — it cannot judge the selectivity of an
 	// unbounded numeric range, so without the id-first barrier it may choose the
-	// ordered scan and walk the whole table for a sparse match set. token is
-	// deliberately NOT here: token equality has reliable MCV statistics, so the
-	// planner already resolves id-first for selective/empty codes and takes the
-	// ordered early-exit for dense ones. Forcing id-first on tokens instead
-	// pessimises the common dense case (e.g. a category code matching most rows),
-	// which then has to materialize and sort the entire match set.
+	// ordered scan and walk the whole table for a sparse match set.
+	//
+	// token is NOT here: it is routed to id-first differently — buildTokenExists
+	// captures a drive candidate (b.driveTable) for a code-equality match, and
+	// applySearchParam flips usesSP on that. This matters because the planner does
+	// NOT reliably drive selective code searches off sp_token — for a sort by
+	// recency + LIMIT it prefers to walk resources by last_updated and probe
+	// sp_token per row, scanning thousands of rows for a code that matches ~0.3%
+	// of resources (measured 77k buffers vs 134 for the id-first shape). Driving
+	// off idx_sp_tok_recent early-exits for both sparse and dense codes, so it is
+	// safe to force; system-only / :text tokens capture nothing and keep the scan.
 	case "quantity", "number", "composite":
 		return true
 	default:
@@ -1087,28 +1098,49 @@ func (b *queryBuilder) buildTokenExists(param, modifier, value string) string {
 	rtP := b.next(b.rt)
 	pP := b.next(param)
 	// :text matches the human-readable display/text of the token (case-insensitive
-	// substring), not its code.
+	// substring), not its code — it can't drive off the code recency index, so no
+	// drive candidate is captured and it keeps the ordered scan.
 	if modifier == "text" {
 		vP := b.next("%" + strings.ToLower(value) + "%")
 		return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND LOWER(s.display) LIKE %s", rtP, pP, vP)
 	}
+	// cond is the correlation-free predicate on alias s. hasCode marks a
+	// code-equality predicate — only those can drive off idx_sp_tok_recent, whose
+	// key is (…, code, last_updated DESC) and which is partial on code IS NOT NULL.
+	var cond string
+	hasCode := false
 	parts := strings.SplitN(value, "|", 2)
 	if len(parts) == 2 {
 		sys, code := parts[0], parts[1]
-		if sys == "" {
-			cP := b.next(code)
-			return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.code = %s", rtP, pP, cP)
-		}
-		if code == "" {
+		switch {
+		case sys == "": // |code
+			cond = fmt.Sprintf("s.code = %s", b.next(code))
+			hasCode = true
+		case code == "": // system|
+			cond = fmt.Sprintf("s.system = %s", b.next(sys))
+		default: // system|code
 			sP := b.next(sys)
-			return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.system = %s", rtP, pP, sP)
+			cP := b.next(code)
+			cond = fmt.Sprintf("s.system = %s AND s.code = %s", sP, cP)
+			hasCode = true
 		}
-		sP := b.next(sys)
-		cP := b.next(code)
-		return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.system = %s AND s.code = %s", rtP, pP, sP, cP)
+	} else {
+		cond = fmt.Sprintf("s.code = %s", b.next(value))
+		hasCode = true
 	}
-	vP := b.next(value)
-	return fmt.Sprintf("SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND s.resource_type = %s AND s.param_name = %s AND s.code = %s", rtP, pP, vP)
+	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
+	// Capture a drive candidate so a lone token search resolves id-first off
+	// idx_sp_tok_recent — walking sp_token newest-first for the code and
+	// early-exiting at the page — instead of the resources recency-walk, which
+	// scans thousands of resource rows probing sp_token per row (measured 77k
+	// buffers vs 134 for the id-first shape). Only a code-equality body qualifies;
+	// a system-only or :text predicate keeps the ordered scan. Skipped in a nested
+	// context (composite / chained / _has), like the numeric builders.
+	if hasCode && !b.suppressDirectDrive {
+		b.driveTable = "sp_token"
+		b.driveBodies = append(b.driveBodies, body)
+	}
+	return "SELECT 1 FROM sp_token s WHERE s.resource_id = r.fhir_id AND " + body
 }
 
 // buildTokenInExists expands a ValueSet URL and builds an IN/NOT IN subquery
@@ -1281,8 +1313,8 @@ func (b *queryBuilder) buildNumberExists(param, value string) string {
 	// id-first CTE straight off sp_number (see fetchSQL). Skipped inside a nested
 	// context (composite / chained / _has), whose full predicate is more than this.
 	if !b.suppressDirectDrive {
-		b.numericTable = "sp_number"
-		b.numericBodies = append(b.numericBodies, body)
+		b.driveTable = "sp_number"
+		b.driveBodies = append(b.driveBodies, body)
 	}
 	return "SELECT 1 FROM sp_number s WHERE s.resource_id = r.fhir_id AND " + body
 }
@@ -1381,8 +1413,8 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	// shared with the EXISTS form below. Skipped inside a nested context (composite
 	// / chained / _has), whose full predicate is more than this one body.
 	if !b.suppressDirectDrive {
-		b.numericTable = "sp_quantity"
-		b.numericBodies = append(b.numericBodies, body)
+		b.driveTable = "sp_quantity"
+		b.driveBodies = append(b.driveBodies, body)
 	}
 	return "SELECT 1 FROM sp_quantity s WHERE s.resource_id = r.fhir_id AND " + body
 }
@@ -1792,12 +1824,12 @@ func (b *queryBuilder) fetchSQL(limit, offset int) string {
 // directDrive reports whether the search is a lone numeric (quantity/number)
 // value predicate sorted by a resources column, so the id-first candidate CTE can
 // be driven straight off the sp_* value index (see directDriveSQL) instead of a
-// correlated EXISTS over resources. numericTable/numericBodies hold the captured
+// correlated EXISTS over resources. driveTable/driveBodies hold the captured
 // scan; predicateCount == 1 guarantees the bodies fully express the match (no
 // other WHERE predicate); orderByResourceIndex keeps the sort mappable to the
 // sp_* columns (last_updated / resource_id).
 func (b *queryBuilder) directDrive(terms []orderTerm) bool {
-	return b.numericTable != "" && len(b.numericBodies) > 0 &&
+	return b.driveTable != "" && len(b.driveBodies) > 0 &&
 		b.predicateCount == 1 && orderByResourceIndex(terms)
 }
 
@@ -1872,7 +1904,7 @@ func (b *queryBuilder) compositeDriveSQL(terms []orderTerm, limit, offset int) s
 // the numeric sp_* value index. The sort keys map from their resources columns to
 // the denormalised sp_* columns (r.last_updated → s.last_updated, r.fhir_id →
 // s.resource_id), both covered by the value index, so the candidate resolve is
-// index-only. The numericBodies reuse the $N args already bound during predicate
+// index-only. The driveBodies reuse the $N args already bound during predicate
 // building; only limit/offset/rt are appended here.
 func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) string {
 	selectList := []string{"s.resource_id AS fhir_id"}
@@ -1883,9 +1915,9 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 		innerOrder = append(innerOrder, alias+" "+t.dir)
 		outerOrder = append(outerOrder, "c."+alias+" "+t.dir)
 	}
-	match := b.numericBodies[0]
-	if len(b.numericBodies) > 1 {
-		match = "(" + strings.Join(b.numericBodies, " OR ") + ")"
+	match := b.driveBodies[0]
+	if len(b.driveBodies) > 1 {
+		match = "(" + strings.Join(b.driveBodies, " OR ") + ")"
 	}
 	limitP := b.next(limit)
 	offsetP := b.next(offset)
@@ -1921,7 +1953,7 @@ func (b *queryBuilder) directDriveSQL(terms []orderTerm, limit, offset int) stri
 			AND r.is_deleted = FALSE
 		ORDER BY %s`,
 		strings.Join(selectList, ", "),
-		b.numericTable, match,
+		b.driveTable, match,
 		strings.Join(innerOrder, ", "), limitP, offsetP,
 		b.rtParam,
 		strings.Join(outerOrder, ", "),

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -17,6 +17,8 @@
 package store
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -137,6 +139,69 @@ func TestFetchSQL_SoleNumericUsesDirectDrive(t *testing.T) {
 	}
 }
 
+var paramRefRE = regexp.MustCompile(`\$(\d+)`)
+
+// assertParamsContiguous fails if the SQL does not reference exactly $1..$nargs.
+// A bound-but-unreferenced placeholder (a gap) makes Postgres unable to infer the
+// parameter's type at execute time — "could not determine data type of parameter
+// $N" (SQLSTATE 42P18) — which substring assertions alone would miss.
+func assertParamsContiguous(t *testing.T, sql string, nargs int) {
+	t.Helper()
+	seen := map[int]bool{}
+	for _, m := range paramRefRE.FindAllStringSubmatch(sql, -1) {
+		n, _ := strconv.Atoi(m[1])
+		seen[n] = true
+	}
+	for i := 1; i <= nargs; i++ {
+		if !seen[i] {
+			t.Errorf("parameter $%d is bound but never referenced (orphan → SQLSTATE 42P18)\nSQL:\n%s", i, sql)
+		}
+	}
+	for n := range seen {
+		if n < 1 || n > nargs {
+			t.Errorf("SQL references $%d but only %d args are bound\nSQL:\n%s", n, nargs, sql)
+		}
+	}
+}
+
+// Every fetch shape must reference exactly the parameters it binds. A gap orphans
+// a placeholder and fails at execute time with SQLSTATE 42P18 — the direct-drive
+// shape hit this by binding writeBase's $1 without referencing it.
+func TestFetchSQL_NoOrphanParams(t *testing.T) {
+	cases := []struct {
+		name   string
+		rt     string
+		params [][2]string
+		sort   string
+	}{
+		{"sole quantity (direct-drive)", "Observation", [][2]string{{"value-quantity", "gt170"}}, ""},
+		{"quantity eq two-bound (direct-drive)", "Observation", [][2]string{{"value-quantity", "5"}}, ""},
+		{"quantity OR list (direct-drive)", "Observation", [][2]string{{"value-quantity", "gt10,lt5"}}, ""},
+		{"quantity system|code (direct-drive)", "Observation", [][2]string{{"value-quantity", "gt5|http://unitsofmeasure.org|mg"}}, ""},
+		{"mixed ref+quantity (correlated id-first)", "Observation", [][2]string{{"subject", "Patient/123"}, {"value-quantity", "gt170"}}, ""},
+		{"quantity sorted by sp_ param (correlated id-first)", "Observation", [][2]string{{"value-quantity", "gt170"}}, "-date"},
+		{"token (single-scan)", "Observation", [][2]string{{"code", "8302-2"}}, ""},
+		{"plain browse (single-scan)", "Observation", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &queryBuilder{rt: tc.rt, reg: idFirstTestRegistry()}
+			b.writeBase()
+			for _, p := range tc.params {
+				b.applyParam(p[0], p[1])
+			}
+			if tc.sort != "" {
+				b.addSort(tc.sort)
+			}
+			if b.err != nil {
+				t.Fatal(b.err)
+			}
+			sql := b.fetchSQL(20, 0)
+			assertParamsContiguous(t, sql, len(b.args))
+		})
+	}
+}
+
 // directDrive engages only for a lone numeric predicate sorted by a resources
 // column. A token predicate (no id-first) and any multi-predicate search must not
 // qualify — they fall back to the ordered scan or the correlated id-first shape.
@@ -164,7 +229,7 @@ func TestDirectDriveGating(t *testing.T) {
 			if b.predicateCount != tc.wantCount {
 				t.Errorf("predicateCount=%d, want %d", b.predicateCount, tc.wantCount)
 			}
-			if got := b.directDrive(); got != tc.wantDirect {
+			if got := b.directDrive(b.orderTerms()); got != tc.wantDirect {
 				t.Errorf("directDrive()=%v, want %v", got, tc.wantDirect)
 			}
 		})

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -165,18 +165,20 @@ func TestCompositeUsesTwoTableDrive(t *testing.T) {
 	sql := b.fetchSQL(20, 0)
 	t.Logf("COMPOSITE_DRIVE_SQL_BEGIN\n%s\nCOMPOSITE_DRIVE_SQL_END", sql)
 	for _, want := range []string{
-		idFirstMarker,
+		directDriveMarker, // early-exit DISTINCT subquery, not a MATERIALIZED CTE
 		"FROM sp_token s",
-		"EXISTS (SELECT 1 FROM sp_quantity s2 WHERE s2.resource_id = s.resource_id",
-		"SELECT DISTINCT fhir_id FROM candidates",
+		"s.last_updated AS sort0", // recency sort key from the driver, mapped
+		"EXISTS (SELECT 1 FROM sp_quantity s2 WHERE s2.resource_id = s.resource_id", // filter component
+		"ORDER BY sort0 DESC LIMIT", // ORDER BY + LIMIT pushed in for early-exit
 	} {
 		if !strings.Contains(sql, want) {
 			t.Fatalf("composite drive SQL missing %q\nSQL:\n%s", want, sql)
 		}
 	}
-	// The candidate CTE must not scan resources (that is the correlated shape).
-	if strings.Contains(sql, "FROM resources r\n\t\t\tWHERE") {
-		t.Fatalf("composite drive should not resolve candidates from resources\nSQL:\n%s", sql)
+	// Early-exit means no MATERIALIZED barrier and no resources scan to resolve
+	// candidates (that was the correlated / full-intersection shape).
+	if strings.Contains(sql, idFirstMarker) {
+		t.Fatalf("composite drive should be early-exit, not a MATERIALIZED CTE\nSQL:\n%s", sql)
 	}
 	assertParamsContiguous(t, sql, len(b.args))
 }

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -84,11 +84,7 @@ func TestFetchSQL_IdFirstGating(t *testing.T) {
 		wantIdFirst bool
 	}{
 		{"quantity uses id-first", "Observation", "value-quantity", "gt170", true},
-		{"code token uses id-first", "Observation", "code", "8302-2", true},
-		{"system|code token uses id-first", "Observation", "code", "http://loinc.org|8302-2", true},
-		{"system-only token keeps ordered scan", "Observation", "code", "http://loinc.org|", false},
-		{"token :text keeps ordered scan", "Observation", "code:text", "gluc", false},
-		{"negated code token keeps ordered scan", "Observation", "code:not", "8302-2", false},
+		{"token keeps ordered scan", "Observation", "code", "8302-2", false},
 		{"reference keeps ordered scan", "Observation", "subject", "Patient/123", false},
 		{"date keeps ordered scan", "Observation", "date", "gt2020", false},
 		{"string keeps ordered scan", "Patient", "name", "Smith", false},
@@ -185,31 +181,6 @@ func TestCompositeUsesTwoTableDrive(t *testing.T) {
 		t.Fatalf("composite drive should be early-exit, not a MATERIALIZED CTE\nSQL:\n%s", sql)
 	}
 	assertParamsContiguous(t, sql, len(b.args))
-}
-
-// A lone code-token search must resolve id-first by driving from sp_token
-// (idx_sp_tok_recent) with the ORDER BY + LIMIT pushed into the candidate
-// subquery to early-exit, rather than the resources recency-walk.
-func TestTokenUsesIdFirstDrive(t *testing.T) {
-	sql := buildSQL(t, "Observation", "code", "8302-2")
-	for _, want := range []string{
-		directDriveMarker, // DISTINCT candidate subquery
-		"FROM sp_token s",
-		"s.last_updated AS sort0",   // recency sort key from the driver
-		"ORDER BY sort0 DESC LIMIT", // pushed in for early-exit
-	} {
-		if !strings.Contains(sql, want) {
-			t.Fatalf("token id-first SQL missing %q\nSQL:\n%s", want, sql)
-		}
-	}
-	// It must NOT drive by walking resources (the old ordered-scan shape).
-	if strings.Contains(sql, "FROM resources r\n\t\tWHERE") {
-		t.Fatalf("token search should not recency-walk resources\nSQL:\n%s", sql)
-	}
-	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
-	b.writeBase()
-	b.applyParam("code", "8302-2")
-	assertParamsContiguous(t, b.fetchSQL(20, 0), len(b.args))
 }
 
 // A composite embedded in a chained search must NOT be captured as a two-table
@@ -322,8 +293,8 @@ func TestNestedNumericNotDirectDrive(t *testing.T) {
 			if b.err != nil {
 				t.Fatal(b.err)
 			}
-			if b.driveTable != "" {
-				t.Errorf("driveTable=%q; a nested numeric must not be captured for direct-drive", b.driveTable)
+			if b.numericTable != "" {
+				t.Errorf("numericTable=%q; a nested numeric must not be captured for direct-drive", b.numericTable)
 			}
 			if b.directDrive(b.orderTerms()) {
 				t.Error("directDrive()=true; a nested numeric must not direct-drive")
@@ -375,10 +346,7 @@ func TestFetchSQL_NoOrphanParams(t *testing.T) {
 		{"mixed ref+quantity (correlated id-first)", "Observation", [][2]string{{"subject", "Patient/123"}, {"value-quantity", "gt170"}}, ""},
 		{"composite token+quantity (two-table drive)", "Observation", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, ""},
 		{"quantity sorted by sp_ param (correlated id-first)", "Observation", [][2]string{{"value-quantity", "gt170"}}, "-date"},
-		{"code token (direct-drive)", "Observation", [][2]string{{"code", "8302-2"}}, ""},
-		{"code token OR list (direct-drive)", "Observation", [][2]string{{"code", "a,b,c"}}, ""},
-		{"system|code token (direct-drive)", "Observation", [][2]string{{"code", "http://loinc.org|8302-2"}}, ""},
-		{"code token sorted by sp_ param (correlated id-first)", "Observation", [][2]string{{"code", "8302-2"}}, "-date"},
+		{"token (single-scan)", "Observation", [][2]string{{"code", "8302-2"}}, ""},
 		{"plain browse (single-scan)", "Observation", nil, ""},
 	}
 	for _, tc := range cases {
@@ -400,9 +368,9 @@ func TestFetchSQL_NoOrphanParams(t *testing.T) {
 	}
 }
 
-// directDrive engages for a lone drivable predicate (numeric value match or a
-// code-token match) sorted by a resources column. Any multi-predicate search
-// must not qualify — it falls back to the correlated id-first CTE.
+// directDrive engages only for a lone numeric predicate sorted by a resources
+// column. A token predicate (no id-first) and any multi-predicate search must not
+// qualify — they fall back to the ordered scan or the correlated id-first shape.
 func TestDirectDriveGating(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -411,7 +379,7 @@ func TestDirectDriveGating(t *testing.T) {
 		wantCount  int
 	}{
 		{"sole quantity", [][2]string{{"value-quantity", "gt170"}}, true, 1},
-		{"sole code token", [][2]string{{"code", "8302-2"}}, true, 1},
+		{"sole token", [][2]string{{"code", "8302-2"}}, false, 1},
 		{"quantity plus token", [][2]string{{"value-quantity", "gt170"}, {"code", "8302-2"}}, false, 2},
 		{"composite embedding quantity", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, false, 1},
 	}

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -62,7 +62,7 @@ func TestFetchSQL_IdFirstGating(t *testing.T) {
 		wantIdFirst bool
 	}{
 		{"quantity uses id-first", "Observation", "value-quantity", "gt170", true},
-		{"token uses id-first", "Observation", "code", "8302-2", true},
+		{"token keeps ordered scan", "Observation", "code", "8302-2", false},
 		{"reference keeps ordered scan", "Observation", "subject", "Patient/123", false},
 		{"date keeps ordered scan", "Observation", "date", "gt2020", false},
 		{"string keeps ordered scan", "Patient", "name", "Smith", false},

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -84,7 +84,11 @@ func TestFetchSQL_IdFirstGating(t *testing.T) {
 		wantIdFirst bool
 	}{
 		{"quantity uses id-first", "Observation", "value-quantity", "gt170", true},
-		{"token keeps ordered scan", "Observation", "code", "8302-2", false},
+		{"code token uses id-first", "Observation", "code", "8302-2", true},
+		{"system|code token uses id-first", "Observation", "code", "http://loinc.org|8302-2", true},
+		{"system-only token keeps ordered scan", "Observation", "code", "http://loinc.org|", false},
+		{"token :text keeps ordered scan", "Observation", "code:text", "gluc", false},
+		{"negated code token keeps ordered scan", "Observation", "code:not", "8302-2", false},
 		{"reference keeps ordered scan", "Observation", "subject", "Patient/123", false},
 		{"date keeps ordered scan", "Observation", "date", "gt2020", false},
 		{"string keeps ordered scan", "Patient", "name", "Smith", false},
@@ -181,6 +185,31 @@ func TestCompositeUsesTwoTableDrive(t *testing.T) {
 		t.Fatalf("composite drive should be early-exit, not a MATERIALIZED CTE\nSQL:\n%s", sql)
 	}
 	assertParamsContiguous(t, sql, len(b.args))
+}
+
+// A lone code-token search must resolve id-first by driving from sp_token
+// (idx_sp_tok_recent) with the ORDER BY + LIMIT pushed into the candidate
+// subquery to early-exit, rather than the resources recency-walk.
+func TestTokenUsesIdFirstDrive(t *testing.T) {
+	sql := buildSQL(t, "Observation", "code", "8302-2")
+	for _, want := range []string{
+		directDriveMarker, // DISTINCT candidate subquery
+		"FROM sp_token s",
+		"s.last_updated AS sort0",   // recency sort key from the driver
+		"ORDER BY sort0 DESC LIMIT", // pushed in for early-exit
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("token id-first SQL missing %q\nSQL:\n%s", want, sql)
+		}
+	}
+	// It must NOT drive by walking resources (the old ordered-scan shape).
+	if strings.Contains(sql, "FROM resources r\n\t\tWHERE") {
+		t.Fatalf("token search should not recency-walk resources\nSQL:\n%s", sql)
+	}
+	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+	b.writeBase()
+	b.applyParam("code", "8302-2")
+	assertParamsContiguous(t, b.fetchSQL(20, 0), len(b.args))
 }
 
 // A composite embedded in a chained search must NOT be captured as a two-table
@@ -293,8 +322,8 @@ func TestNestedNumericNotDirectDrive(t *testing.T) {
 			if b.err != nil {
 				t.Fatal(b.err)
 			}
-			if b.numericTable != "" {
-				t.Errorf("numericTable=%q; a nested numeric must not be captured for direct-drive", b.numericTable)
+			if b.driveTable != "" {
+				t.Errorf("driveTable=%q; a nested numeric must not be captured for direct-drive", b.driveTable)
 			}
 			if b.directDrive(b.orderTerms()) {
 				t.Error("directDrive()=true; a nested numeric must not direct-drive")
@@ -346,7 +375,10 @@ func TestFetchSQL_NoOrphanParams(t *testing.T) {
 		{"mixed ref+quantity (correlated id-first)", "Observation", [][2]string{{"subject", "Patient/123"}, {"value-quantity", "gt170"}}, ""},
 		{"composite token+quantity (two-table drive)", "Observation", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, ""},
 		{"quantity sorted by sp_ param (correlated id-first)", "Observation", [][2]string{{"value-quantity", "gt170"}}, "-date"},
-		{"token (single-scan)", "Observation", [][2]string{{"code", "8302-2"}}, ""},
+		{"code token (direct-drive)", "Observation", [][2]string{{"code", "8302-2"}}, ""},
+		{"code token OR list (direct-drive)", "Observation", [][2]string{{"code", "a,b,c"}}, ""},
+		{"system|code token (direct-drive)", "Observation", [][2]string{{"code", "http://loinc.org|8302-2"}}, ""},
+		{"code token sorted by sp_ param (correlated id-first)", "Observation", [][2]string{{"code", "8302-2"}}, "-date"},
 		{"plain browse (single-scan)", "Observation", nil, ""},
 	}
 	for _, tc := range cases {
@@ -368,9 +400,9 @@ func TestFetchSQL_NoOrphanParams(t *testing.T) {
 	}
 }
 
-// directDrive engages only for a lone numeric predicate sorted by a resources
-// column. A token predicate (no id-first) and any multi-predicate search must not
-// qualify — they fall back to the ordered scan or the correlated id-first shape.
+// directDrive engages for a lone drivable predicate (numeric value match or a
+// code-token match) sorted by a resources column. Any multi-predicate search
+// must not qualify — it falls back to the correlated id-first CTE.
 func TestDirectDriveGating(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -379,7 +411,7 @@ func TestDirectDriveGating(t *testing.T) {
 		wantCount  int
 	}{
 		{"sole quantity", [][2]string{{"value-quantity", "gt170"}}, true, 1},
-		{"sole token", [][2]string{{"code", "8302-2"}}, false, 1},
+		{"sole code token", [][2]string{{"code", "8302-2"}}, true, 1},
 		{"quantity plus token", [][2]string{{"value-quantity", "gt170"}, {"code", "8302-2"}}, false, 2},
 		{"composite embedding quantity", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, false, 1},
 	}

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -102,6 +102,114 @@ func TestFetchSQL_IdFirstGating(t *testing.T) {
 	}
 }
 
+// A multi-value reference search (comma = OR) must coalesce into a single EXISTS
+// with target_id = ANY(...), not OR-ed separate EXISTS subqueries. The lone
+// EXISTS lets Postgres drive from the sp_reference target index; OR-of-EXISTS
+// defeats that inversion and forces a full recency-walk over resources.
+func TestMultiValueReferenceUsesAnyArray(t *testing.T) {
+	cases := []struct {
+		name       string
+		key, value string
+		wantTypes  []string // target_type literals expected in the SQL
+	}{
+		{"same type", "subject", "Patient/1,Patient/2", []string{"Patient"}},
+		{"typed via modifier", "subject:Patient", "1,2,3", []string{"Patient"}},
+		{"mixed types grouped", "subject", "Patient/1,Group/2,Patient/3", []string{"Patient", "Group"}},
+		{"bare ids", "subject", "1,2", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+			b.writeBase()
+			b.applyParam(tc.key, tc.value)
+			if b.err != nil {
+				t.Fatal(b.err)
+			}
+			sql := b.fetchSQL(20, 0)
+			if !strings.Contains(sql, "= ANY(") {
+				t.Fatalf("multi-value reference should use = ANY(...)\nSQL:\n%s", sql)
+			}
+			if strings.Contains(sql, "OR EXISTS") {
+				t.Fatalf("multi-value reference must not OR separate EXISTS subqueries\nSQL:\n%s", sql)
+			}
+			if n := strings.Count(sql, "FROM sp_reference s"); n != 1 {
+				t.Fatalf("want exactly one sp_reference scan, got %d\nSQL:\n%s", n, sql)
+			}
+			for _, ty := range tc.wantTypes {
+				if !strings.Contains(sql, "s.target_type = ") {
+					t.Fatalf("expected a target_type predicate for %q\nSQL:\n%s", ty, sql)
+				}
+			}
+			// Bare ids carry no target_type filter.
+			if tc.wantTypes == nil && strings.Contains(sql, "s.target_type") {
+				t.Fatalf("bare-id reference should not filter target_type\nSQL:\n%s", sql)
+			}
+			assertParamsContiguous(t, sql, len(b.args))
+		})
+	}
+}
+
+// A lone composite (token + quantity) must resolve candidates by driving from
+// the selective token component's table, filtering by the quantity component as
+// a nested EXISTS, rather than the correlated CTE that scans resources first.
+func TestCompositeUsesTwoTableDrive(t *testing.T) {
+	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+	b.writeBase()
+	b.applyParam("code-value-quantity", "8480-6$gt110")
+	if b.err != nil {
+		t.Fatal(b.err)
+	}
+	if b.comp == nil {
+		t.Fatal("composite drive was not captured")
+	}
+	sql := b.fetchSQL(20, 0)
+	t.Logf("COMPOSITE_DRIVE_SQL_BEGIN\n%s\nCOMPOSITE_DRIVE_SQL_END", sql)
+	for _, want := range []string{
+		idFirstMarker,
+		"FROM sp_token s",
+		"EXISTS (SELECT 1 FROM sp_quantity s2 WHERE s2.resource_id = s.resource_id",
+		"SELECT DISTINCT fhir_id FROM candidates",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("composite drive SQL missing %q\nSQL:\n%s", want, sql)
+		}
+	}
+	// The candidate CTE must not scan resources (that is the correlated shape).
+	if strings.Contains(sql, "FROM resources r\n\t\t\tWHERE") {
+		t.Fatalf("composite drive should not resolve candidates from resources\nSQL:\n%s", sql)
+	}
+	assertParamsContiguous(t, sql, len(b.args))
+}
+
+// A composite embedded in a chained search must NOT be captured as a two-table
+// drive (it is not the sole top-level predicate); it keeps the correlated shape.
+func TestNestedCompositeNotDriven(t *testing.T) {
+	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+	b.writeBase()
+	// A composite plus another predicate: predicateCount > 1, drive must not engage.
+	b.applyParam("code-value-quantity", "8480-6$gt110")
+	b.applyParam("date", "gt2020")
+	if b.err != nil {
+		t.Fatal(b.err)
+	}
+	if b.compositeDriveOK(b.orderTerms()) {
+		t.Fatal("composite drive must not engage when other predicates are present")
+	}
+	assertParamsContiguous(t, b.fetchSQL(20, 0), len(b.args))
+}
+
+// A single-value reference keeps the plain equality form (no ANY), so we do not
+// regress the common case into an array bind.
+func TestSingleValueReferenceKeepsEquality(t *testing.T) {
+	sql := buildSQL(t, "Observation", "subject", "Patient/123")
+	if strings.Contains(sql, "= ANY(") {
+		t.Fatalf("single-value reference should use plain equality, not ANY(...)\nSQL:\n%s", sql)
+	}
+	if !strings.Contains(sql, "s.target_id = $") {
+		t.Fatalf("single-value reference should match target_id by equality\nSQL:\n%s", sql)
+	}
+}
+
 // A search that mixes a reference filter (ordered-scan-friendly) with a quantity
 // filter must still use id-first: the quantity predicate is the one that can
 // degrade into a full scan.
@@ -234,7 +342,7 @@ func TestFetchSQL_NoOrphanParams(t *testing.T) {
 		{"quantity OR list (direct-drive)", "Observation", [][2]string{{"value-quantity", "gt10,lt5"}}, ""},
 		{"quantity system|code (direct-drive)", "Observation", [][2]string{{"value-quantity", "gt5|http://unitsofmeasure.org|mg"}}, ""},
 		{"mixed ref+quantity (correlated id-first)", "Observation", [][2]string{{"subject", "Patient/123"}, {"value-quantity", "gt170"}}, ""},
-		{"composite token+quantity (correlated id-first)", "Observation", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, ""},
+		{"composite token+quantity (two-table drive)", "Observation", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, ""},
 		{"quantity sorted by sp_ param (correlated id-first)", "Observation", [][2]string{{"value-quantity", "gt170"}}, "-date"},
 		{"token (single-scan)", "Observation", [][2]string{{"code", "8302-2"}}, ""},
 		{"plain browse (single-scan)", "Observation", nil, ""},

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -37,6 +37,8 @@ func idFirstTestRegistry() *searchparam.Registry {
 		{ResourceType: "Observation", ParamName: "subject", ParamType: "reference", Targets: []string{"Patient"}},
 		{ResourceType: "Observation", ParamName: "date", ParamType: "date"},
 		{ResourceType: "Patient", ParamName: "name", ParamType: "string"},
+		// A numeric Patient param, reached only via a chained search (subject.pat-qty).
+		{ResourceType: "Patient", ParamName: "pat-qty", ParamType: "quantity", FHIRPath: "Patient.patQty"},
 		// A composite embedding a token + quantity component — exercises the
 		// direct-drive suppression inside buildCompositeExists.
 		{ResourceType: "Observation", ParamName: "code-value-quantity", ParamType: "composite",
@@ -143,6 +145,36 @@ func TestFetchSQL_SoleNumericUsesDirectDrive(t *testing.T) {
 	// The candidate CTE resolves off sp_quantity, not a correlated EXISTS over resources.
 	if strings.Contains(sql, "EXISTS (SELECT 1 FROM sp_quantity") {
 		t.Fatalf("direct-drive should not use a correlated EXISTS\nSQL:\n%s", sql)
+	}
+}
+
+// A numeric value embedded in a nested context (composite component, chained
+// target, or _has value) must never be captured as a direct-drive candidate —
+// only a bare top-level numeric predicate qualifies. Capturing it would drive the
+// fetch off just that embedded body, dropping the surrounding structure (wrong
+// results, orphaned params → SQLSTATE 42P18).
+func TestNestedNumericNotDirectDrive(t *testing.T) {
+	cases := []struct{ name, rt, key, val string }{
+		{"composite component", "Observation", "code-value-quantity", "8480-6$gt110"},
+		{"chained target", "Observation", "subject:Patient.pat-qty", "gt5"},
+		{"_has value", "Patient", "_has:Observation:subject:value-quantity", "gt5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &queryBuilder{rt: tc.rt, reg: idFirstTestRegistry()}
+			b.writeBase()
+			b.applyParam(tc.key, tc.val)
+			if b.err != nil {
+				t.Fatal(b.err)
+			}
+			if b.numericTable != "" {
+				t.Errorf("numericTable=%q; a nested numeric must not be captured for direct-drive", b.numericTable)
+			}
+			if b.directDrive(b.orderTerms()) {
+				t.Error("directDrive()=true; a nested numeric must not direct-drive")
+			}
+			assertParamsContiguous(t, b.fetchSQL(20, 0), len(b.args))
+		})
 	}
 }
 

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -51,7 +51,7 @@ func buildSQL(t *testing.T, rt, rawKey, value string) string {
 	if b.err != nil {
 		t.Fatalf("applyParam(%q=%q): %v", rawKey, value, b.err)
 	}
-	return b.fetchSQL(20, 0, false)
+	return b.fetchSQL(20, 0)
 }
 
 func TestFetchSQL_IdFirstGating(t *testing.T) {
@@ -91,7 +91,7 @@ func TestFetchSQL_MixedParamsUseIdFirst(t *testing.T) {
 	if b.err != nil {
 		t.Fatal(b.err)
 	}
-	if sql := b.fetchSQL(20, 0, false); !strings.Contains(sql, idFirstMarker) {
+	if sql := b.fetchSQL(20, 0); !strings.Contains(sql, idFirstMarker) {
 		t.Fatalf("expected id-first for mixed reference+quantity search\nSQL:\n%s", sql)
 	}
 }
@@ -106,7 +106,7 @@ func TestFetchSQL_IdFirstCarriesSortKey(t *testing.T) {
 	if b.err != nil {
 		t.Fatal(b.err)
 	}
-	sql := b.fetchSQL(20, 0, false)
+	sql := b.fetchSQL(20, 0)
 	for _, want := range []string{idFirstMarker, "AS sort0", "ORDER BY sort0", "ORDER BY c.sort0"} {
 		if !strings.Contains(sql, want) {
 			t.Fatalf("id-first sort SQL missing %q\nSQL:\n%s", want, sql)
@@ -114,33 +114,42 @@ func TestFetchSQL_IdFirstCarriesSortKey(t *testing.T) {
 	}
 }
 
-// A numeric search the probe has confirmed dense (dense=true) must switch to the
-// ordered single-scan shape rather than materialize the whole candidate set.
-func TestFetchSQL_DenseNumericUsesOrderedScan(t *testing.T) {
+// A sole numeric predicate sorted by a resources column uses the direct-drive
+// id-first shape: the candidate CTE resolves straight off the sp_* value index
+// (FROM sp_quantity s) using the denormalised last_updated, rather than scanning
+// resources with a correlated EXISTS.
+func TestFetchSQL_SoleNumericUsesDirectDrive(t *testing.T) {
 	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
 	b.writeBase()
 	b.applyParam("value-quantity", "gt170")
 	if b.err != nil {
 		t.Fatal(b.err)
 	}
-	if sql := b.fetchSQL(20, 0, true); strings.Contains(sql, idFirstMarker) {
-		t.Fatalf("dense numeric search should use ordered single-scan, got id-first\nSQL:\n%s", sql)
+	sql := b.fetchSQL(20, 0)
+	for _, want := range []string{idFirstMarker, "FROM sp_quantity s", "s.resource_id AS fhir_id", "s.last_updated"} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("direct-drive SQL missing %q\nSQL:\n%s", want, sql)
+		}
+	}
+	// The candidate CTE resolves off sp_quantity, not a correlated EXISTS over resources.
+	if strings.Contains(sql, "EXISTS (SELECT 1 FROM sp_quantity") {
+		t.Fatalf("direct-drive should not use a correlated EXISTS\nSQL:\n%s", sql)
 	}
 }
 
-// probeDense only engages for a sole numeric predicate; the builder tracks
-// numericSP and predicateCount to gate it. Token predicates and multi-predicate
-// searches must not qualify (their probe would be expensive).
-func TestProbeGating(t *testing.T) {
+// directDrive engages only for a lone numeric predicate sorted by a resources
+// column. A token predicate (no id-first) and any multi-predicate search must not
+// qualify — they fall back to the ordered scan or the correlated id-first shape.
+func TestDirectDriveGating(t *testing.T) {
 	cases := []struct {
-		name        string
-		params      [][2]string
-		wantNumeric bool
-		wantCount   int
+		name       string
+		params     [][2]string
+		wantDirect bool
+		wantCount  int
 	}{
 		{"sole quantity", [][2]string{{"value-quantity", "gt170"}}, true, 1},
 		{"sole token", [][2]string{{"code", "8302-2"}}, false, 1},
-		{"quantity plus token", [][2]string{{"value-quantity", "gt170"}, {"code", "8302-2"}}, true, 2},
+		{"quantity plus token", [][2]string{{"value-quantity", "gt170"}, {"code", "8302-2"}}, false, 2},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -152,17 +161,11 @@ func TestProbeGating(t *testing.T) {
 			if b.err != nil {
 				t.Fatal(b.err)
 			}
-			if b.numericSP != tc.wantNumeric {
-				t.Errorf("numericSP=%v, want %v", b.numericSP, tc.wantNumeric)
-			}
 			if b.predicateCount != tc.wantCount {
 				t.Errorf("predicateCount=%d, want %d", b.predicateCount, tc.wantCount)
 			}
-			// The gate: probe runs only for a sole numeric predicate.
-			eligible := b.numericSP && b.predicateCount == 1 && b.orderByResourceIndex()
-			wantEligible := tc.wantNumeric && tc.wantCount == 1
-			if eligible != wantEligible {
-				t.Errorf("probe-eligible=%v, want %v", eligible, wantEligible)
+			if got := b.directDrive(); got != tc.wantDirect {
+				t.Errorf("directDrive()=%v, want %v", got, tc.wantDirect)
 			}
 		})
 	}

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -32,11 +32,18 @@ const idFirstMarker = "WITH candidates AS MATERIALIZED"
 func idFirstTestRegistry() *searchparam.Registry {
 	reg := searchparam.NewRegistry()
 	for _, d := range []searchparam.Definition{
-		{ResourceType: "Observation", ParamName: "value-quantity", ParamType: "quantity"},
-		{ResourceType: "Observation", ParamName: "code", ParamType: "token"},
+		{ResourceType: "Observation", ParamName: "value-quantity", ParamType: "quantity", FHIRPath: "Observation.value.ofType(Quantity)"},
+		{ResourceType: "Observation", ParamName: "code", ParamType: "token", FHIRPath: "Observation.code"},
 		{ResourceType: "Observation", ParamName: "subject", ParamType: "reference", Targets: []string{"Patient"}},
 		{ResourceType: "Observation", ParamName: "date", ParamType: "date"},
 		{ResourceType: "Patient", ParamName: "name", ParamType: "string"},
+		// A composite embedding a token + quantity component — exercises the
+		// direct-drive suppression inside buildCompositeExists.
+		{ResourceType: "Observation", ParamName: "code-value-quantity", ParamType: "composite",
+			Components: []searchparam.ComponentDef{
+				{Expression: "Observation.code"},
+				{Expression: "Observation.value.ofType(Quantity)"},
+			}},
 	} {
 		reg.Upsert(d)
 	}
@@ -179,6 +186,7 @@ func TestFetchSQL_NoOrphanParams(t *testing.T) {
 		{"quantity OR list (direct-drive)", "Observation", [][2]string{{"value-quantity", "gt10,lt5"}}, ""},
 		{"quantity system|code (direct-drive)", "Observation", [][2]string{{"value-quantity", "gt5|http://unitsofmeasure.org|mg"}}, ""},
 		{"mixed ref+quantity (correlated id-first)", "Observation", [][2]string{{"subject", "Patient/123"}, {"value-quantity", "gt170"}}, ""},
+		{"composite token+quantity (correlated id-first)", "Observation", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, ""},
 		{"quantity sorted by sp_ param (correlated id-first)", "Observation", [][2]string{{"value-quantity", "gt170"}}, "-date"},
 		{"token (single-scan)", "Observation", [][2]string{{"code", "8302-2"}}, ""},
 		{"plain browse (single-scan)", "Observation", nil, ""},
@@ -215,6 +223,7 @@ func TestDirectDriveGating(t *testing.T) {
 		{"sole quantity", [][2]string{{"value-quantity", "gt170"}}, true, 1},
 		{"sole token", [][2]string{{"code", "8302-2"}}, false, 1},
 		{"quantity plus token", [][2]string{{"value-quantity", "gt170"}, {"code", "8302-2"}}, false, 2},
+		{"composite embedding quantity", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, false, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wso2/fhir-server/internal/searchparam"
+)
+
+// idFirstMarker uniquely identifies the id-first fetch shape produced by
+// fetchSQL. The ordered-scan shape never contains a CTE.
+const idFirstMarker = "WITH candidates AS MATERIALIZED"
+
+func idFirstTestRegistry() *searchparam.Registry {
+	reg := searchparam.NewRegistry()
+	for _, d := range []searchparam.Definition{
+		{ResourceType: "Observation", ParamName: "value-quantity", ParamType: "quantity"},
+		{ResourceType: "Observation", ParamName: "code", ParamType: "token"},
+		{ResourceType: "Observation", ParamName: "subject", ParamType: "reference", Targets: []string{"Patient"}},
+		{ResourceType: "Observation", ParamName: "date", ParamType: "date"},
+		{ResourceType: "Patient", ParamName: "name", ParamType: "string"},
+	} {
+		reg.Upsert(d)
+	}
+	return reg
+}
+
+// buildSQL runs a single-param search through the builder and returns the fetch
+// SQL it would execute for the first page.
+func buildSQL(t *testing.T, rt, rawKey, value string) string {
+	t.Helper()
+	b := &queryBuilder{rt: rt, reg: idFirstTestRegistry()}
+	b.writeBase()
+	b.applyParam(rawKey, value)
+	if b.err != nil {
+		t.Fatalf("applyParam(%q=%q): %v", rawKey, value, b.err)
+	}
+	return b.fetchSQL(20, 0)
+}
+
+func TestFetchSQL_IdFirstGating(t *testing.T) {
+	cases := []struct {
+		name        string
+		rt          string
+		key, value  string
+		wantIdFirst bool
+	}{
+		{"quantity uses id-first", "Observation", "value-quantity", "gt170", true},
+		{"token uses id-first", "Observation", "code", "8302-2", true},
+		{"reference keeps ordered scan", "Observation", "subject", "Patient/123", false},
+		{"date keeps ordered scan", "Observation", "date", "gt2020", false},
+		{"string keeps ordered scan", "Patient", "name", "Smith", false},
+		{"negated quantity keeps ordered scan", "Observation", "value-quantity:not", "gt170", false},
+		{"plain browse keeps ordered scan", "Observation", "_lastUpdated", "gt2020", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sql := buildSQL(t, tc.rt, tc.key, tc.value)
+			got := strings.Contains(sql, idFirstMarker)
+			if got != tc.wantIdFirst {
+				t.Fatalf("id-first=%v, want %v\nSQL:\n%s", got, tc.wantIdFirst, sql)
+			}
+		})
+	}
+}
+
+// A search that mixes a reference filter (ordered-scan-friendly) with a quantity
+// filter must still use id-first: the quantity predicate is the one that can
+// degrade into a full scan.
+func TestFetchSQL_MixedParamsUseIdFirst(t *testing.T) {
+	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+	b.writeBase()
+	b.applyParam("subject", "Patient/123")
+	b.applyParam("value-quantity", "gt170")
+	if b.err != nil {
+		t.Fatal(b.err)
+	}
+	if sql := b.fetchSQL(20, 0); !strings.Contains(sql, idFirstMarker) {
+		t.Fatalf("expected id-first for mixed reference+quantity search\nSQL:\n%s", sql)
+	}
+}
+
+// The id-first query must carry the sort key through the candidate CTE and
+// re-apply it after the resource_json join, so ordering survives pagination.
+func TestFetchSQL_IdFirstCarriesSortKey(t *testing.T) {
+	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+	b.writeBase()
+	b.applyParam("value-quantity", "gt170")
+	b.addSort("-date")
+	if b.err != nil {
+		t.Fatal(b.err)
+	}
+	sql := b.fetchSQL(20, 0)
+	for _, want := range []string{idFirstMarker, "AS sort0", "ORDER BY sort0", "ORDER BY c.sort0"} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("id-first sort SQL missing %q\nSQL:\n%s", want, sql)
+		}
+	}
+}

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -51,7 +51,7 @@ func buildSQL(t *testing.T, rt, rawKey, value string) string {
 	if b.err != nil {
 		t.Fatalf("applyParam(%q=%q): %v", rawKey, value, b.err)
 	}
-	return b.fetchSQL(20, 0)
+	return b.fetchSQL(20, 0, false)
 }
 
 func TestFetchSQL_IdFirstGating(t *testing.T) {
@@ -91,7 +91,7 @@ func TestFetchSQL_MixedParamsUseIdFirst(t *testing.T) {
 	if b.err != nil {
 		t.Fatal(b.err)
 	}
-	if sql := b.fetchSQL(20, 0); !strings.Contains(sql, idFirstMarker) {
+	if sql := b.fetchSQL(20, 0, false); !strings.Contains(sql, idFirstMarker) {
 		t.Fatalf("expected id-first for mixed reference+quantity search\nSQL:\n%s", sql)
 	}
 }
@@ -106,10 +106,64 @@ func TestFetchSQL_IdFirstCarriesSortKey(t *testing.T) {
 	if b.err != nil {
 		t.Fatal(b.err)
 	}
-	sql := b.fetchSQL(20, 0)
+	sql := b.fetchSQL(20, 0, false)
 	for _, want := range []string{idFirstMarker, "AS sort0", "ORDER BY sort0", "ORDER BY c.sort0"} {
 		if !strings.Contains(sql, want) {
 			t.Fatalf("id-first sort SQL missing %q\nSQL:\n%s", want, sql)
 		}
+	}
+}
+
+// A numeric search the probe has confirmed dense (dense=true) must switch to the
+// ordered single-scan shape rather than materialize the whole candidate set.
+func TestFetchSQL_DenseNumericUsesOrderedScan(t *testing.T) {
+	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+	b.writeBase()
+	b.applyParam("value-quantity", "gt170")
+	if b.err != nil {
+		t.Fatal(b.err)
+	}
+	if sql := b.fetchSQL(20, 0, true); strings.Contains(sql, idFirstMarker) {
+		t.Fatalf("dense numeric search should use ordered single-scan, got id-first\nSQL:\n%s", sql)
+	}
+}
+
+// probeDense only engages for a sole numeric predicate; the builder tracks
+// numericSP and predicateCount to gate it. Token predicates and multi-predicate
+// searches must not qualify (their probe would be expensive).
+func TestProbeGating(t *testing.T) {
+	cases := []struct {
+		name        string
+		params      [][2]string
+		wantNumeric bool
+		wantCount   int
+	}{
+		{"sole quantity", [][2]string{{"value-quantity", "gt170"}}, true, 1},
+		{"sole token", [][2]string{{"code", "8302-2"}}, false, 1},
+		{"quantity plus token", [][2]string{{"value-quantity", "gt170"}, {"code", "8302-2"}}, true, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
+			b.writeBase()
+			for _, p := range tc.params {
+				b.applyParam(p[0], p[1])
+			}
+			if b.err != nil {
+				t.Fatal(b.err)
+			}
+			if b.numericSP != tc.wantNumeric {
+				t.Errorf("numericSP=%v, want %v", b.numericSP, tc.wantNumeric)
+			}
+			if b.predicateCount != tc.wantCount {
+				t.Errorf("predicateCount=%d, want %d", b.predicateCount, tc.wantCount)
+			}
+			// The gate: probe runs only for a sole numeric predicate.
+			eligible := b.numericSP && b.predicateCount == 1 && b.orderByResourceIndex()
+			wantEligible := tc.wantNumeric && tc.wantCount == 1
+			if eligible != wantEligible {
+				t.Errorf("probe-eligible=%v, want %v", eligible, wantEligible)
+			}
+		})
 	}
 }

--- a/internal/store/search_idfirst_test.go
+++ b/internal/store/search_idfirst_test.go
@@ -25,9 +25,20 @@ import (
 	"github.com/wso2/fhir-server/internal/searchparam"
 )
 
-// idFirstMarker uniquely identifies the id-first fetch shape produced by
-// fetchSQL. The ordered-scan shape never contains a CTE.
+// fetchSQL produces two id-first shapes, both distinct from the plain
+// ordered-scan (which is a bare "FROM resources r WHERE …"):
+//   - correlated id-first (composite / multi-predicate): a MATERIALIZED CTE.
+//   - direct-drive (a lone numeric predicate sorted by a resources column): a
+//     DISTINCT candidate subquery driven straight off the sp_* index, with the
+//     ORDER BY + LIMIT pushed in so a dense predicate early-exits.
 const idFirstMarker = "WITH candidates AS MATERIALIZED"
+const directDriveMarker = "SELECT DISTINCT"
+
+// usesIdFirst reports whether the fetch SQL is one of the id-first shapes
+// (rather than the plain ordered scan over resources).
+func usesIdFirst(sql string) bool {
+	return strings.Contains(sql, idFirstMarker) || strings.Contains(sql, directDriveMarker)
+}
 
 func idFirstTestRegistry() *searchparam.Registry {
 	reg := searchparam.NewRegistry()
@@ -83,7 +94,7 @@ func TestFetchSQL_IdFirstGating(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			sql := buildSQL(t, tc.rt, tc.key, tc.value)
-			got := strings.Contains(sql, idFirstMarker)
+			got := usesIdFirst(sql)
 			if got != tc.wantIdFirst {
 				t.Fatalf("id-first=%v, want %v\nSQL:\n%s", got, tc.wantIdFirst, sql)
 			}
@@ -126,9 +137,10 @@ func TestFetchSQL_IdFirstCarriesSortKey(t *testing.T) {
 }
 
 // A sole numeric predicate sorted by a resources column uses the direct-drive
-// id-first shape: the candidate CTE resolves straight off the sp_* value index
-// (FROM sp_quantity s) using the denormalised last_updated, rather than scanning
-// resources with a correlated EXISTS.
+// id-first shape: a DISTINCT candidate subquery resolves straight off the sp_*
+// index (FROM sp_quantity s) with the ORDER BY + LIMIT pushed in so a dense
+// predicate early-exits, rather than scanning resources with a correlated
+// EXISTS or materialising the whole match set in a CTE.
 func TestFetchSQL_SoleNumericUsesDirectDrive(t *testing.T) {
 	b := &queryBuilder{rt: "Observation", reg: idFirstTestRegistry()}
 	b.writeBase()
@@ -137,12 +149,16 @@ func TestFetchSQL_SoleNumericUsesDirectDrive(t *testing.T) {
 		t.Fatal(b.err)
 	}
 	sql := b.fetchSQL(20, 0)
-	for _, want := range []string{idFirstMarker, "FROM sp_quantity s", "s.resource_id AS fhir_id", "s.last_updated"} {
+	for _, want := range []string{directDriveMarker, "FROM sp_quantity s", "s.resource_id AS fhir_id", "s.last_updated", "LIMIT"} {
 		if !strings.Contains(sql, want) {
 			t.Fatalf("direct-drive SQL missing %q\nSQL:\n%s", want, sql)
 		}
 	}
-	// The candidate CTE resolves off sp_quantity, not a correlated EXISTS over resources.
+	// Early-exit shape: no MATERIALIZED barrier (which would force resolving the
+	// whole match set before the LIMIT) and no correlated EXISTS over resources.
+	if strings.Contains(sql, idFirstMarker) {
+		t.Fatalf("direct-drive must not use a MATERIALIZED CTE (defeats early-exit)\nSQL:\n%s", sql)
+	}
 	if strings.Contains(sql, "EXISTS (SELECT 1 FROM sp_quantity") {
 		t.Fatalf("direct-drive should not use a correlated EXISTS\nSQL:\n%s", sql)
 	}

--- a/internal/store/search_paramsweep_test.go
+++ b/internal/store/search_paramsweep_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wso2/fhir-server/internal/searchparam"
+)
+
+// paramSweepRegistry covers every sp_* value type plus composite so the sweep
+// exercises each value-predicate builder.
+func paramSweepRegistry() *searchparam.Registry {
+	reg := searchparam.NewRegistry()
+	for _, d := range []searchparam.Definition{
+		{ResourceType: "Observation", ParamName: "value-quantity", ParamType: "quantity", FHIRPath: "Observation.value.ofType(Quantity)"},
+		{ResourceType: "Observation", ParamName: "combo-value-quantity", ParamType: "quantity", FHIRPath: "Observation.xx"},
+		{ResourceType: "Observation", ParamName: "some-number", ParamType: "number", FHIRPath: "Observation.nn"},
+		{ResourceType: "Observation", ParamName: "code", ParamType: "token", FHIRPath: "Observation.code"},
+		{ResourceType: "Observation", ParamName: "category", ParamType: "token"},
+		{ResourceType: "Observation", ParamName: "subject", ParamType: "reference", Targets: []string{"Patient"}},
+		{ResourceType: "Observation", ParamName: "date", ParamType: "date"},
+		{ResourceType: "Observation", ParamName: "some-uri", ParamType: "uri"},
+		{ResourceType: "Observation", ParamName: "code-value-quantity", ParamType: "composite",
+			Components: []searchparam.ComponentDef{{Expression: "Observation.code"}, {Expression: "Observation.value.ofType(Quantity)"}}},
+		{ResourceType: "Patient", ParamName: "name", ParamType: "string"},
+		{ResourceType: "Patient", ParamName: "birthdate", ParamType: "date"},
+		{ResourceType: "Patient", ParamName: "pat-qty", ParamType: "quantity", FHIRPath: "Patient.patQty"},
+	} {
+		reg.Upsert(d)
+	}
+	return reg
+}
+
+// TestParamSweep_NoOrphanParams exhaustively builds the fetch AND count SQL for a
+// broad matrix of search shapes — every value type, its modifiers, comma-OR
+// lists, composite, chained (typed and untyped), _has, _sort variants, and
+// multi-predicate combos — and asserts each references exactly $1..$N with no
+// gaps. A gap orphans a bound parameter and fails at execute time with SQLSTATE
+// 42P18 ("could not determine data type of parameter $N"). Count SQL is checked
+// against the args bound before fetch appends order/limit (mirroring
+// fetchWithCount, where count runs first). Every one of these was also verified
+// to PREPARE against live PostgreSQL.
+func TestParamSweep_NoOrphanParams(t *testing.T) {
+	reg := paramSweepRegistry()
+	cases := []struct {
+		name   string
+		rt     string
+		params [][2]string
+		sort   string
+	}{
+		{"string plain", "Patient", [][2]string{{"name", "Smith"}}, ""},
+		{"string exact", "Patient", [][2]string{{"name:exact", "Smith"}}, ""},
+		{"string contains", "Patient", [][2]string{{"name:contains", "mit"}}, ""},
+		{"string missing", "Patient", [][2]string{{"name:missing", "true"}}, ""},
+		{"token code", "Observation", [][2]string{{"code", "8302-2"}}, ""},
+		{"token sys|code", "Observation", [][2]string{{"code", "http://loinc.org|8302-2"}}, ""},
+		{"token OR", "Observation", [][2]string{{"code", "a,b,c"}}, ""},
+		{"token not", "Observation", [][2]string{{"code:not", "x"}}, ""},
+		{"token missing", "Observation", [][2]string{{"category:missing", "false"}}, ""},
+		{"date eq", "Observation", [][2]string{{"date", "2020"}}, ""},
+		{"date gt", "Observation", [][2]string{{"date", "gt2020-01-01"}}, ""},
+		{"date lt", "Observation", [][2]string{{"date", "lt2020"}}, ""},
+		{"date ge", "Observation", [][2]string{{"date", "ge2020"}}, ""},
+		{"date le", "Observation", [][2]string{{"date", "le2020"}}, ""},
+		{"date ne", "Observation", [][2]string{{"date", "ne2020"}}, ""},
+		{"date OR", "Patient", [][2]string{{"birthdate", "gt1990,lt1980"}}, ""},
+		{"number gt", "Observation", [][2]string{{"some-number", "gt5"}}, ""},
+		{"number lt", "Observation", [][2]string{{"some-number", "lt5"}}, ""},
+		{"number eq", "Observation", [][2]string{{"some-number", "5"}}, ""},
+		{"number OR", "Observation", [][2]string{{"some-number", "gt1,lt9"}}, ""},
+		{"qty gt", "Observation", [][2]string{{"value-quantity", "gt170"}}, ""},
+		{"qty lt", "Observation", [][2]string{{"value-quantity", "lt170"}}, ""},
+		{"qty ge", "Observation", [][2]string{{"value-quantity", "ge170"}}, ""},
+		{"qty le", "Observation", [][2]string{{"value-quantity", "le170"}}, ""},
+		{"qty ne", "Observation", [][2]string{{"value-quantity", "ne170"}}, ""},
+		{"qty eq", "Observation", [][2]string{{"value-quantity", "170"}}, ""},
+		{"qty sys|code", "Observation", [][2]string{{"value-quantity", "gt5|http://unitsofmeasure.org|mg"}}, ""},
+		{"qty OR", "Observation", [][2]string{{"value-quantity", "gt10,lt5"}}, ""},
+		{"qty combo", "Observation", [][2]string{{"combo-value-quantity", "gt140"}}, ""},
+		{"qty missing", "Observation", [][2]string{{"value-quantity:missing", "true"}}, ""},
+		{"qty not", "Observation", [][2]string{{"value-quantity:not", "gt5"}}, ""},
+		{"uri exact", "Observation", [][2]string{{"some-uri", "http://x/y"}}, ""},
+		{"uri below", "Observation", [][2]string{{"some-uri:below", "http://x"}}, ""},
+		{"uri above", "Observation", [][2]string{{"some-uri:above", "http://x/y/z"}}, ""},
+		{"ref typed", "Observation", [][2]string{{"subject", "Patient/123"}}, ""},
+		{"ref bare", "Observation", [][2]string{{"subject", "123"}}, ""},
+		{"ref OR", "Observation", [][2]string{{"subject", "Patient/1,Patient/2"}}, ""},
+		{"ref identifier", "Observation", [][2]string{{"subject:identifier", "sys|val"}}, ""},
+		{"composite", "Observation", [][2]string{{"code-value-quantity", "8480-6$gt110"}}, ""},
+		{"chained typed string", "Observation", [][2]string{{"subject:Patient.name", "Smith"}}, ""},
+		{"chained typed qty", "Observation", [][2]string{{"subject:Patient.pat-qty", "gt5"}}, ""},
+		{"chained untyped", "Observation", [][2]string{{"subject.name", "Smith"}}, ""},
+		{"_has qty", "Patient", [][2]string{{"_has:Observation:subject:value-quantity", "gt5"}}, ""},
+		{"_has token", "Patient", [][2]string{{"_has:Observation:subject:code", "x"}}, ""},
+		{"qty sort sp_", "Observation", [][2]string{{"value-quantity", "gt170"}}, "date"},
+		{"qty sort lastUpdated", "Observation", [][2]string{{"value-quantity", "gt170"}}, "-_lastUpdated"},
+		{"qty sort id", "Observation", [][2]string{{"value-quantity", "gt170"}}, "_id"},
+		{"token sort sp_", "Observation", [][2]string{{"code", "x"}}, "date"},
+		{"browse sort", "Observation", nil, "-date"},
+		{"multi qty+token", "Observation", [][2]string{{"value-quantity", "gt170"}, {"code", "x"}}, ""},
+		{"multi qty+ref+date", "Observation", [][2]string{{"value-quantity", "gt170"}, {"subject", "Patient/1"}, {"date", "gt2020"}}, ""},
+		{"multi token+token", "Observation", [][2]string{{"code", "x"}, {"category", "y"}}, ""},
+		{"multi num+qty", "Observation", [][2]string{{"some-number", "gt5"}, {"value-quantity", "lt9"}}, ""},
+		{"_id single", "Observation", [][2]string{{"_id", "abc"}}, ""},
+		{"_id OR", "Observation", [][2]string{{"_id", "a,b"}}, ""},
+		{"_lastUpdated", "Observation", [][2]string{{"_lastUpdated", "gt2020"}}, ""},
+		{"plain browse", "Observation", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &queryBuilder{rt: tc.rt, reg: reg}
+			b.writeBase()
+			for _, p := range tc.params {
+				b.applyParam(p[0], p[1])
+			}
+			if tc.sort != "" {
+				b.addSort(tc.sort)
+			}
+			if b.err != nil {
+				t.Fatalf("build error: %v", b.err)
+			}
+			// count runs before fetch appends order/limit args.
+			assertParamsContiguous(t, fmt.Sprintf("SELECT COUNT(*) FROM resources r WHERE %s", b.where.String()), len(b.args))
+			assertParamsContiguous(t, b.fetchSQL(20, 0), len(b.args))
+		})
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -159,7 +159,7 @@ func (s *Store) createInTx(ctx context.Context, tx pgx.Tx, resourceType string, 
 		resourceID, resourceType, now, raw,
 	)
 	slog.Debug("creating resource", "type", resourceType, "id", resourceID)
-	s.extractor.Queue(batch, resourceType, resourceID, body)
+	s.extractor.Queue(batch, resourceType, resourceID, body, now)
 	spCount := batch.Len() - 1 // number of sp_* statements queued
 	queueHistory(batch, resourceType, resourceID, 1, "POST", raw, now)
 
@@ -280,7 +280,7 @@ func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 		newVersion, lastUpdated, raw, resourceID, resourceType,
 	)
 	nDeletes := index.QueueDelete(batch, resourceType, resourceID) // nDeletes DELETEs at positions 1-nDeletes
-	s.extractor.Queue(batch, resourceType, resourceID, body)
+	s.extractor.Queue(batch, resourceType, resourceID, body, lastUpdated)
 	spInsertEnd := batch.Len() // position just before history INSERT
 	queueHistory(batch, resourceType, resourceID, newVersion, "PUT", raw, lastUpdated)
 
@@ -390,7 +390,7 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 		newVersion, now, mergedRaw, resourceID, resourceType,
 	)
 	nDeletes := index.QueueDelete(batch, resourceType, resourceID)
-	s.extractor.Queue(batch, resourceType, resourceID, merged)
+	s.extractor.Queue(batch, resourceType, resourceID, merged, now)
 	spInsertEnd := batch.Len()
 	queueHistory(batch, resourceType, resourceID, newVersion, "PATCH", mergedRaw, now)
 


### PR DESCRIPTION
## Context (supersedes #23 and #25)

- **#23** made sparse/empty numeric searches drive from the `sp_*` index (id-first) instead of a `resources` full-scan. That's the right call — it holds ~200 tps under load. Its one flaw: the `MATERIALIZED` CTE resolves and top-N sorts the **whole** match set before the `LIMIT`, so a **dense** predicate (e.g. `value-quantity=le140`, ~500k rows) paid ~200ms / ~1s cold. This was the reported slow query.
- **#25** tried "trust the planner, no id-first". Under concurrency it collapsed to **~25 tps**: on sparse/empty/composite values the planner bets on an ordered early-exit and instead full-scans `resources` for **9–46s** (confirmed in `pg_stat_statements`); a handful of those saturate every core under 30 VUs.

The lesson: the id-first barrier is **load-bearing** (the planner genuinely can't cost the correlated `EXISTS` + `ORDER BY` + `LIMIT` case), but it must not defeat early-exit for dense predicates.

## Change

Replace the `MATERIALIZED` CTE in `directDriveSQL` with a `DISTINCT` candidate subquery that pushes `ORDER BY … LIMIT` inside, and add a **recency covering index** (`idx_sp_qty_recent` / `idx_sp_num_recent`, `… , last_updated DESC` INCLUDE the value columns + `resource_id`). The planner then chooses per bound value from the single `sp_*` table's own statistics (`force_custom_plan`):

- **dense**, sorted by recency → recency index, walk newest-first, filter on the INCLUDE'd value columns, **stop after one page**;
- **sparse / empty** → value index, few/zero rows, **never a `resources` full-scan**.

`DISTINCT` dedupes resources with multiple matching `sp_*` rows (the old direct-drive shape could emit duplicate resources / break page size).

## Validation (perf dataset: 1.66M resources, 1.15M `sp_quantity`)

`EXPLAIN ANALYZE`:

| Search | Before | After |
|---|---|---|
| `combo-value-quantity=le140` (dense 88%) | ~200ms (500k materialise+sort) | **0.63ms** (33 index rows, early-exit) |
| `value-quantity=gt200` (sparse) | — | **0.68ms** |
| `value-quantity=99999` (empty) | 3.9s full-scan | **86ms** (bounded, no full-scan) |

pgbench, 30 clients, 90% fast / 10% empty-tail:

| Query shape | tps |
|---|---|
| plain planner-only (#25) | ~7 |
| **id-first early-exit (this PR)** | **~680** |

Intra-query parallelism was measured to be a non-factor once the shape is fixed (parallel vs serial within ~2%), so it's deliberately left untouched.

`go build`, `go vet`, `gofmt`, full test suite pass. Adds one commit on top of #23.

> Note: needs a full end-to-end k6 run on the perf box (deploying this build) to confirm the aggregate app-level TPS; the numbers above are DB-layer (`EXPLAIN` + pgbench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)