### PR TITLE
perf: range-overlap GiST index for quantity search + TEXT/lz4 resource_json storage

### DIFF
--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -17,6 +17,17 @@ CREATE TABLE IF NOT EXISTS schema_version (
 -- No GIN index is created on resource_json because all searches go through the
 -- sp_* tables; indexing the entire document would cost ~2.4x on writes with no
 -- benefit to the query patterns used here.
+--
+-- resource_json is TEXT, not JSONB. The document is always read and written whole
+-- (the store binds/scans it as an opaque []byte — no ->/->>/@> operators or any
+-- other server-side JSON access anywhere), so JSONB bought nothing but its costs:
+-- parse-and-normalise on every write and the loss of key order / whitespace. TEXT
+-- keeps the exact bytes the store marshalled. COMPRESSION lz4 (PostgreSQL 14+)
+-- compresses the TOAST'd document far faster than the default pglz at a similar
+-- ratio, cutting write CPU on these large columns. Note: SET COMPRESSION only
+-- governs newly written values, so on an existing deployment the type/compression
+-- change applies to new writes; see the PR notes for the out-of-band rewrite to
+-- convert already-stored rows.
 
 CREATE TABLE IF NOT EXISTS resources (
     tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
@@ -25,7 +36,7 @@ CREATE TABLE IF NOT EXISTS resources (
     version_id    INT          NOT NULL DEFAULT 1,
     last_updated  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     is_deleted    BOOLEAN      NOT NULL DEFAULT FALSE,
-    resource_json JSONB        NOT NULL,
+    resource_json TEXT         COMPRESSION lz4 NOT NULL,
     search_text   TSVECTOR,
     PRIMARY KEY (tenant_id, resource_type, fhir_id)
 );
@@ -49,7 +60,7 @@ CREATE TABLE IF NOT EXISTS resource_history (
     version_id    INT          NOT NULL,
     operation     VARCHAR(10)  NOT NULL,   -- CREATE | UPDATE | DELETE
     recorded_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    resource_json JSONB,
+    resource_json TEXT COMPRESSION lz4,    -- opaque snapshot; see resources.resource_json
     UNIQUE (tenant_id, fhir_id, resource_type, version_id)
 );
 

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -623,3 +623,71 @@ ALTER TABLE sp_token ADD COLUMN IF NOT EXISTS last_updated TIMESTAMPTZ NOT NULL 
 CREATE INDEX IF NOT EXISTS idx_sp_tok_recent ON sp_token (tenant_id, resource_type, param_name, code, last_updated DESC) INCLUDE (resource_id, system) WHERE code IS NOT NULL;
 
 INSERT INTO schema_version (version) VALUES (11) ON CONFLICT DO NOTHING;
+
+-- v12: range-overlap GiST index on sp_quantity for the bounded quantity searches
+-- (eq / ne / ge / le), reachable only through the numrange && operator.
+--
+-- Those prefixes are interval overlap — value_low <= searchHigh AND value_high >=
+-- searchLow — but expressed as two independent numeric bounds the predicate can
+-- only ride the btree value indexes (idx_sp_qty_raw / idx_sp_qty_recent). A dense
+-- bounded window (e.g. value-quantity=ge10&le140 covering a large slice of one
+-- (tenant, type, param) partition) still had to scan-and-filter that whole
+-- partition. A GiST index over the stored interval answers the same overlap with
+-- a range probe. buildQuantityExists now emits the predicate as
+-- numrange(s.value_low, s.value_high, '[]') && numrange(searchLow, searchHigh, '[]');
+-- the index expression below must stay byte-for-byte identical to that stored
+-- numrange, or the planner will not match it. gt/lt stay scalar (strict, not
+-- overlap) and keep using the btree value indexes.
+--
+-- The leading (tenant_id, resource_type, param_name) equality columns are varchar,
+-- which have no default gist opclass, so the multicolumn GiST needs btree_gist.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE INDEX IF NOT EXISTS idx_sp_qty_range_gist ON sp_quantity
+    USING gist (tenant_id, resource_type, param_name, numrange(value_low, value_high, '[]'));
+-- Production build note: on an existing large sp_quantity, build this out of band
+-- with CREATE INDEX CONCURRENTLY before deploying the paired search.go change —
+-- CONCURRENTLY cannot run inside schema.sql's single implicit transaction:
+--   CREATE INDEX CONCURRENTLY idx_sp_qty_range_gist ON sp_quantity
+--       USING gist (tenant_id, resource_type, param_name,
+--                   numrange(value_low, value_high, '[]'));
+
+-- LEAKPROOF the two functions the overlap predicate is built from, so it reaches
+-- the GiST index under RLS. Under the FORCE ROW LEVEL SECURITY barrier on the
+-- sp_* tables (see the tenant_isolation policy above) a qual is only pushed below
+-- the barrier — and thus eligible to become an index cond — if EVERY function it
+-- calls is LEAKPROOF; otherwise it is held back as a post-filter above the
+-- barrier. This is the same barrier the v9 numeric-operator marking addressed. The
+-- predicate is  numrange(s.value_low, s.value_high, '[]') && numrange($lo, $hi, '[]'),
+-- so both the && operator (range_overlaps) AND the numrange constructor that runs
+-- per row on value_low/value_high must be leakproof. Verified: with only
+-- range_overlaps marked, the && stays a recheck filter under RLS and the GiST
+-- index is never used to narrow by range (measured on PostgreSQL 15); marking both
+-- pushes && into the GiST Index Cond. Leaving it half-done would also strand the
+-- v10 recency early-exit, whose value filter over idx_sp_qty_recent would no longer
+-- push into the scan.
+--
+-- Safety. range_overlaps is pure bound arithmetic and cannot leak. numrange is
+-- less obvious: its 3-arg constructor raises "range lower bound must be less than
+-- or equal to range upper bound" when lower > upper, and an argument-dependent
+-- error is normally a side channel that disqualifies LEAKPROOF. It is safe HERE
+-- because the expression index above computes the very same
+-- numrange(value_low, value_high, '[]') for every row at write time — a row that
+-- would make the constructor throw cannot be inserted while the index exists — so
+-- the query-time constructor never errors on stored data. Caveat: LEAKPROOF is a
+-- global property of the function, so it relaxes numrange() everywhere; this schema
+-- uses numrange only for this index, but a future RLS table that constructs
+-- numrange over unconstrained numerics would inherit the relaxed barrier. Same
+-- superuser caveat / defensive wrapper as v9: a non-super DDL role still applies
+-- the rest of the schema, and these searches fall back to the correct, slower
+-- post-filter path.
+DO $leakproof_range$
+BEGIN
+    ALTER FUNCTION range_overlaps(anyrange, anyrange) LEAKPROOF;
+    ALTER FUNCTION numrange(numeric, numeric, text) LEAKPROOF;
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RAISE NOTICE 'skipping LEAKPROOF on range_overlaps/numrange (requires superuser); bounded quantity searches under RLS will use a slower post-filter';
+END
+$leakproof_range$;
+
+INSERT INTO schema_version (version) VALUES (12) ON CONFLICT DO NOTHING;

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1349,6 +1349,19 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	// Compare the indexed range against the search range endpoints (mirrors
 	// buildDateExists) so boundary values are not matched incorrectly — e.g. an
 	// indexed 5 must not satisfy gt5.
+	//
+	// eq/ne/ge/le are interval overlap: the stored [value_low, value_high] band
+	// and the search band match iff value_low <= searchHigh AND value_high >=
+	// searchLow. Emitting that as a numrange && numrange (overlaps) lets the
+	// planner reach idx_sp_qty_range_gist (schema v12) instead of only the btree
+	// value indexes — the scalar two-bound form cannot touch the GiST expression
+	// index. The stored numrange bracket must match the index expression exactly
+	// (numrange(value_low, value_high, '[]')) or the planner won't recognise it.
+	// A NULL numrange bound is unbounded, giving the one-sided ge/le prefixes the
+	// half-open search band they need. gt/lt are strict — the stored band lies
+	// entirely above/below the search point, which is not overlap — so they stay
+	// as scalar bound comparisons (still served by idx_sp_qty_raw / _recent).
+	const stored = "numrange(s.value_low, s.value_high, '[]')"
 	var cond string
 	switch prefix {
 	case "gt":
@@ -1356,17 +1369,19 @@ func (b *queryBuilder) buildQuantityExists(param, value string) string {
 	case "lt":
 		cond = fmt.Sprintf("s.value_high < %s", b.next(low))
 	case "ge":
-		cond = fmt.Sprintf("s.value_high >= %s", b.next(low))
+		// [searchLow, ∞) — overlap iff value_high >= searchLow.
+		cond = fmt.Sprintf("%s && numrange(%s, NULL, '[]')", stored, b.next(low))
 	case "le":
-		cond = fmt.Sprintf("s.value_low <= %s", b.next(high))
+		// (-∞, searchHigh] — overlap iff value_low <= searchHigh.
+		cond = fmt.Sprintf("%s && numrange(NULL, %s, '[]')", stored, b.next(high))
 	case "ne":
-		hP := b.next(high)
 		lP := b.next(low)
-		cond = fmt.Sprintf("NOT (s.value_low <= %s AND s.value_high >= %s)", hP, lP)
+		hP := b.next(high)
+		cond = fmt.Sprintf("NOT (%s && numrange(%s, %s, '[]'))", stored, lP, hP)
 	default: // eq
-		hP := b.next(high)
 		lP := b.next(low)
-		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", hP, lP)
+		hP := b.next(high)
+		cond = fmt.Sprintf("%s && numrange(%s, %s, '[]')", stored, lP, hP)
 	}
 
 	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)

--- a/internal/store/search_paramsweep_test.go
+++ b/internal/store/search_paramsweep_test.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/wso2/fhir-server/internal/searchparam"
@@ -140,4 +141,81 @@ func TestParamSweep_NoOrphanParams(t *testing.T) {
 			assertParamsContiguous(t, b.fetchSQL(20, 0), len(b.args))
 		})
 	}
+}
+
+// TestQuantityRangeOverlap asserts that the bounded quantity prefixes (eq/ne/ge/le)
+// emit the numrange && (overlaps) form so the planner can reach the GiST index
+// idx_sp_qty_range_gist (schema v12), while the strict gt/lt prefixes stay as
+// scalar bound comparisons. The stored numrange must be byte-for-byte identical
+// to the index expression — numrange(s.value_low, s.value_high, '[]') — or the
+// planner will not match it, which is the whole point of the change.
+func TestQuantityRangeOverlap(t *testing.T) {
+	reg := paramSweepRegistry()
+	const storedRange = "numrange(s.value_low, s.value_high, '[]')"
+
+	overlap := []struct{ name, value string }{
+		{"eq", "170"},
+		{"ne", "ne170"},
+		{"ge", "ge170"},
+		{"le", "le170"},
+	}
+	for _, tc := range overlap {
+		t.Run("overlap/"+tc.name, func(t *testing.T) {
+			b := &queryBuilder{rt: "Observation", reg: reg}
+			b.writeBase()
+			b.applyParam("value-quantity", tc.value)
+			if b.err != nil {
+				t.Fatalf("build error: %v", b.err)
+			}
+			sql := b.where.String()
+			if !strings.Contains(sql, storedRange+" &&") {
+				t.Errorf("%s: expected numrange overlap against %q, got:\n%s", tc.name, storedRange, sql)
+			}
+			if strings.Contains(sql, "s.value_low <=") || strings.Contains(sql, "s.value_high >=") {
+				t.Errorf("%s: still emitting scalar two-bound predicate, got:\n%s", tc.name, sql)
+			}
+		})
+	}
+
+	scalar := []struct{ name, value, want string }{
+		{"gt", "gt170", "s.value_low >"},
+		{"lt", "lt170", "s.value_high <"},
+	}
+	for _, tc := range scalar {
+		t.Run("scalar/"+tc.name, func(t *testing.T) {
+			b := &queryBuilder{rt: "Observation", reg: reg}
+			b.writeBase()
+			b.applyParam("value-quantity", tc.value)
+			if b.err != nil {
+				t.Fatalf("build error: %v", b.err)
+			}
+			sql := b.where.String()
+			if !strings.Contains(sql, tc.want) {
+				t.Errorf("%s: expected scalar bound %q, got:\n%s", tc.name, tc.want, sql)
+			}
+			if strings.Contains(sql, "&&") {
+				t.Errorf("%s: strict prefix must not use range overlap, got:\n%s", tc.name, sql)
+			}
+		})
+	}
+
+	// One-sided bounds must be half-open: a NULL numrange bound is unbounded, so
+	// ge is [low, ∞) and le is (-∞, high] — the equivalents of value_high >= low
+	// and value_low <= high the scalar form computed.
+	t.Run("ge/half-open-low", func(t *testing.T) {
+		b := &queryBuilder{rt: "Observation", reg: reg}
+		b.writeBase()
+		b.applyParam("value-quantity", "ge170")
+		if got := b.where.String(); !strings.Contains(got, ", NULL, '[]')") {
+			t.Errorf("ge: expected unbounded upper (…, NULL, '[]'), got:\n%s", got)
+		}
+	})
+	t.Run("le/half-open-high", func(t *testing.T) {
+		b := &queryBuilder{rt: "Observation", reg: reg}
+		b.writeBase()
+		b.applyParam("value-quantity", "le170")
+		if got := b.where.String(); !strings.Contains(got, "numrange(NULL, ") {
+			t.Errorf("le: expected unbounded lower numrange(NULL, …), got:\n%s", got)
+		}
+	})
 }


### PR DESCRIPTION
This PR carries two independent storage/search performance changes.

---

## 1. Range-overlap GiST index for bounded quantity searches

Bounded quantity searches (`eq`/`ne`/`ge`/`le`) compute interval overlap, but the current builder emits it as a **scalar two-bound predicate**:

```
s.value_low <= $hi AND s.value_high >= $lo
```

Expressed as two independent numeric bounds, that can only ride the btree value indexes (`idx_sp_qty_raw` / `idx_sp_qty_recent`). A dense bounded window — e.g. `value-quantity=ge10&le140` over a large `(tenant, type, param)` partition — still scans and filters the whole partition.

This emits the predicate as a **numrange overlap** so the planner can reach a GiST index over the stored interval:

```
numrange(s.value_low, s.value_high, '[]') && numrange($lo, $hi, '[]')
```

`&&` (overlaps) is exactly what the scalar `value_low <= hi AND value_high >= lo` computed — those two conditions *are* the definition of interval overlap — so **the row set is unchanged; only how it is computed changes.** One-sided `ge`/`le` use a half-open search range (a `NULL` numrange bound is unbounded: `ge` → `[lo,)`, `le` → `(,hi]`). `gt`/`lt` stay scalar: the stored band lies *strictly* above/below the search point, which is not overlap, and they keep using the btree value indexes.

### Schema (v12)

- `CREATE EXTENSION btree_gist` + `idx_sp_qty_range_gist` on `(tenant_id, resource_type, param_name, numrange(value_low, value_high, '[]'))`. The index expression matches the emitted predicate byte-for-byte so the planner recognises it. `schema.sql` runs as one implicit transaction, so the index is created non-`CONCURRENTLY` there; an in-file note gives the `CONCURRENTLY` form for building it out of band on an existing large table.
- Mark **both** `range_overlaps` **and** the `numrange(numeric, numeric, text)` constructor `LEAKPROOF`.

#### ⚠️ Review focus: the `numrange` LEAKPROOF marking

Under `FORCE ROW LEVEL SECURITY` (all `sp_*` tables) a qual only pushes below the security barrier — and thus becomes an index cond — if **every** function it calls is leakproof. This is the same barrier the v9 numeric-operator marking addressed. The predicate calls the `numrange()` constructor per row on `value_low`/`value_high`, so it must qualify too.

- `range_overlaps` is pure bound arithmetic → safe, same argument as v9.
- `numrange` is subtler: its 3-arg constructor raises an error when `lower > upper`, and an argument-dependent error is normally a side channel that disqualifies `LEAKPROOF`. It is safe **here** because the expression index computes the same `numrange(value_low, value_high, '[]')` for every row at write time — a row that would make the constructor throw cannot be inserted while the index exists — so the query-time constructor never errors on stored data. **Caveat:** `LEAKPROOF` is global to the function, so it relaxes `numrange()` everywhere; this schema uses `numrange` only for this index. Full reasoning is in the `schema.sql` v12 comment.

Same superuser caveat / defensive `DO` wrapper as v9: a non-super DDL role still applies the rest of the schema and these searches fall back to the correct, slower post-filter path.

### Verification (PostgreSQL 15)

- `schema.sql` applies clean from scratch.
- **Row-set equivalence** — scalar vs. overlap counts identical for `eq` (21=21), `ge` (2011=2011), `le` (510=510), `ne` (4979=4979).
- **Index reachability** — `&&` pushes into `Bitmap Index Scan on idx_sp_qty_range_gist` (Index Cond), including the half-open `ge`/`le` forms.
- **RLS matters** — with only `range_overlaps` marked, `&&` stays a recheck filter under RLS and the GiST index never narrows by range; marking `numrange` too pushes `&&` into the GiST Index Cond. Confirmed the planner picks `idx_sp_qty_range_gist` **naturally** (no forcing, all real indexes present, 60k rows) for a selective range under RLS.
- Adds `TestQuantityRangeOverlap` locking in the emitted `&&` operator, the scalar `gt`/`lt` fallback, and the half-open one-sided bounds.

---

## 2. `resource_json` stored as TEXT with lz4 compression

The FHIR document in `resources.resource_json` and `resource_history.resource_json` is always read and written **whole** — the store binds and scans it as an opaque `[]byte`, and no query anywhere uses a JSON operator (`->`, `->>`, `@>`, `jsonb_*`) or any other server-side JSON access (searches all go through the `sp_*` tables). JSONB therefore bought nothing but its costs: a parse-and-normalise on every write and the loss of the exact bytes the store marshalled.

Both columns become `TEXT COMPRESSION lz4` (PostgreSQL 14+). TEXT stores the marshalled bytes verbatim; lz4 compresses the TOAST'd document far faster than the default pglz at a comparable ratio, cutting write-path CPU on these large columns.

- **No Go change** — pgx already round-trips these columns as `[]byte`, which encodes/scans identically against TEXT.
- **New deployments only** — `CREATE TABLE IF NOT EXISTS` does not alter an existing table, so established installs keep JSONB and behave identically (opaque `[]byte` either way). Converting already-stored rows is an out-of-band rewrite, e.g.:
  ```sql
  ALTER TABLE resources        ALTER COLUMN resource_json SET DATA TYPE text, ALTER COLUMN resource_json SET COMPRESSION lz4;
  ALTER TABLE resource_history ALTER COLUMN resource_json SET DATA TYPE text, ALTER COLUMN resource_json SET COMPRESSION lz4;
  -- SET COMPRESSION only affects new writes; VACUUM FULL / rewrite to recompress existing rows.
  ```

### Verification (PostgreSQL 16)

- lz4 present in `postgres:16-alpine`; schema applies clean with `attcompression='l'` on both columns.
- Full **store** and **handler** integration suites pass unchanged: create / read / update / patch / delete, history + vread, search, tenant isolation, and SearchParameter reads — confirming the `[]byte`↔TEXT round-trip end to end.