### PR TITLE
refactor(db): reorganize schema.sql for a fresh-database install

### DIFF
--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -1,22 +1,49 @@
 -- FHIR Server PostgreSQL Schema
 -- One resources table holds all FHIR resource types. Separate sp_* tables
 -- store extracted search parameter values so searches never touch resource_json.
--- Requires PostgreSQL 13+. For Location near-search, install PostGIS.
+-- Requires PostgreSQL 14+ (resource_json uses COMPRESSION lz4). For Location
+-- near-search, install PostGIS. The btree_gist extension is created by this
+-- script for the quantity range GiST index (see sp_quantity).
+--
+-- Layout:
+--   1. Schema version table
+--   2. Core resource storage      (resources, resource_history)
+--   3. Search parameter indexes   (sp_string, sp_token, sp_date, sp_number,
+--                                  sp_quantity, sp_uri, sp_reference, sp_coords)
+--   4. Registry & reference data  (search_param_definitions, ig_*,
+--                                  base_definitions, closure tables)
+--   5. Planner statistics
+--   6. Autovacuum tuning
+--   7. Row-Level Security
+--   8. LEAKPROOF operators
+--
+-- Each table is defined together with all of its own indexes. Every statement is
+-- idempotent (CREATE ... IF NOT EXISTS), so the schema can be (re)applied to a
+-- fresh database and re-running is a no-op.
 
--- ─── Schema version ──────────────────────────────────────────────────────────
--- Tracks the schema revision applied to this database.
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 1. Schema version
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Records the schema revision this file creates.
 
 CREATE TABLE IF NOT EXISTS schema_version (
     version     INT         NOT NULL PRIMARY KEY,
     upgraded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- ─── Master resource table ────────────────────────────────────────────────────
--- Stores every FHIR resource. resource_json holds the full FHIR document.
--- search_text is a pre-built tsvector used for _text / _content full-text search.
--- No GIN index is created on resource_json because all searches go through the
--- sp_* tables; indexing the entire document would cost ~2.4x on writes with no
--- benefit to the query patterns used here.
+INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;
+
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 2. Core resource storage
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ─── resources ───────────────────────────────────────────────────────────────
+-- Stores every FHIR resource; resource_json holds the full FHIR document.
+-- search_text is a pre-built tsvector for _text / _content full-text search.
+-- No index is built on resource_json: all searches go through the sp_* tables,
+-- and indexing the whole document would cost ~2.4x on writes for no benefit here.
 --
 -- resource_json is TEXT, not JSONB. The document is always read and written whole
 -- (the store binds/scans it as an opaque []byte — no ->/->>/@> operators or any
@@ -24,10 +51,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
 -- parse-and-normalise on every write and the loss of key order / whitespace. TEXT
 -- keeps the exact bytes the store marshalled. COMPRESSION lz4 (PostgreSQL 14+)
 -- compresses the TOAST'd document far faster than the default pglz at a similar
--- ratio, cutting write CPU on these large columns. Note: SET COMPRESSION only
--- governs newly written values, so on an existing deployment the type/compression
--- change applies to new writes; see the PR notes for the out-of-band rewrite to
--- convert already-stored rows.
+-- ratio, cutting write CPU on these large columns.
 
 CREATE TABLE IF NOT EXISTS resources (
     tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
@@ -41,14 +65,14 @@ CREATE TABLE IF NOT EXISTS resources (
     PRIMARY KEY (tenant_id, resource_type, fhir_id)
 );
 
--- List all resources of a type ordered by recency (used by GET /{type}).
+-- List all resources of a type, newest first (GET /{type}).
 CREATE INDEX IF NOT EXISTS idx_res_type_updated ON resources (tenant_id, resource_type, last_updated DESC);
--- Same as above but skips soft-deleted resources (used by most searches).
+-- Same, but skipping soft-deleted rows (used by most searches).
 CREATE INDEX IF NOT EXISTS idx_res_active       ON resources (tenant_id, resource_type, last_updated DESC) WHERE is_deleted = FALSE;
--- Full-text search over search_text (_text / _content search parameters).
+-- Full-text search over search_text (_text / _content).
 CREATE INDEX IF NOT EXISTS idx_res_search_text  ON resources USING GIN (search_text);
 
--- ─── Version history ──────────────────────────────────────────────────────────
+-- ─── resource_history ────────────────────────────────────────────────────────
 -- Append-only log of every create, update, and delete. Each row is a full
 -- snapshot of resource_json at that version, enabling vread and audit trails.
 
@@ -71,10 +95,30 @@ CREATE INDEX IF NOT EXISTS idx_hist_time      ON resource_history (tenant_id, re
 -- History feed for a single resource type ordered by time (GET /{type}/_history).
 CREATE INDEX IF NOT EXISTS idx_hist_type_time ON resource_history (tenant_id, resource_type, recorded_at DESC);
 
--- ─── String search index ─────────────────────────────────────────────────────
--- Stores extracted values for FHIR string search parameters (name, address, etc.).
--- value_exact keeps the original casing for the :exact modifier.
--- value_lower stores the downcased value for the default case-insensitive prefix match.
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 3. Search parameter indexes (sp_*)
+-- ═══════════════════════════════════════════════════════════════════════════
+-- One table per FHIR search parameter type. Each holds values extracted from
+-- resource_json at write time and cascades on delete of its parent resource.
+--
+-- Two index families recur across these tables:
+--   *_source  — leads on (tenant_id, resource_id, resource_type) to serve the
+--               per-resource EXISTS probe of multi-parameter searches (correlated
+--               on resource_id/resource_type; see internal/store/search.go) and
+--               the per-resource re-index DELETE / FK ON DELETE CASCADE. Trailing
+--               param_name + value columns let the probe resolve its predicate
+--               index-only instead of heap-fetching every row of the candidate
+--               resource.
+--   *_recent  — leads on the value/lookup key but orders by last_updated DESC and
+--               INCLUDEs the sort/join columns, so a recency-sorted search walks
+--               newest-first and stops after one page instead of materialising and
+--               top-N sorting a dense match set.
+
+-- ─── sp_string ───────────────────────────────────────────────────────────────
+-- FHIR string search parameters (name, address, etc.).
+-- value_exact keeps the original casing for the :exact modifier;
+-- value_lower is the downcased value for the default case-insensitive prefix match.
 
 CREATE TABLE IF NOT EXISTS sp_string (
     id            BIGSERIAL    PRIMARY KEY,
@@ -88,26 +132,21 @@ CREATE TABLE IF NOT EXISTS sp_string (
 );
 
 -- text_pattern_ops is required for LIKE 'prefix%' to use a btree index under
--- non-C collations (e.g. en_US.utf8). Without it, prefix scans fall back to
--- a sequential scan. The operator class also serves equality lookups.
+-- non-C collations (e.g. en_US.utf8); without it, prefix scans fall back to a
+-- sequential scan. The operator class also serves equality lookups.
 CREATE INDEX IF NOT EXISTS idx_sp_str_lower_pattern ON sp_string (tenant_id, resource_type, param_name, value_lower text_pattern_ops);
 CREATE INDEX IF NOT EXISTS idx_sp_str_exact         ON sp_string (tenant_id, resource_type, param_name, value_exact);
--- Leading on resource_id serves the per-resource EXISTS probe of multi-parameter
--- searches (correlated on resource_id/resource_type) and per-resource re-index
--- DELETEs / FK ON DELETE CASCADE. param_name + value_lower let the probe narrow
--- to the parameter and resolve its value predicate index-only, instead of heap-
--- fetching every sp_string row of the candidate resource. (The v5 diet slimmed
--- this to (resource_id, resource_type); that regressed multi-param search — see
--- the schema_version v8 note below.)
 CREATE INDEX IF NOT EXISTS idx_sp_str_source        ON sp_string (tenant_id, resource_id, resource_type, param_name, value_lower);
 -- Uncomment for :contains support (requires pg_trgm extension):
 -- CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- CREATE INDEX idx_sp_str_trgm ON sp_string USING GIN (value_lower gin_trgm_ops);
 
--- ─── Token search index ───────────────────────────────────────────────────────
--- Stores extracted values for FHIR token search parameters
--- (CodeableConcept, Coding, Identifier, code, boolean).
--- display is stored to support the :text modifier (match on the human label).
+-- ─── sp_token ────────────────────────────────────────────────────────────────
+-- FHIR token search parameters (CodeableConcept, Coding, Identifier, code, boolean).
+-- display supports the :text modifier (match on the human label).
+-- last_updated is a denormalised copy of resources.last_updated, set at index
+-- time, so idx_sp_tok_recent can walk newest-first for a code without a
+-- resources lookup.
 
 CREATE TABLE IF NOT EXISTS sp_token (
     id            BIGSERIAL    PRIMARY KEY,
@@ -118,38 +157,33 @@ CREATE TABLE IF NOT EXISTS sp_token (
     system        VARCHAR(512),
     code          VARCHAR(191),
     display       VARCHAR(512),
-    -- Denormalised copy of resources.last_updated, set at index time. Lets the
-    -- composite early-exit drive (fetchSQL's composite shape) walk sp_token
-    -- newest-first for a code and stop after one page, without a resources lookup.
     last_updated  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
 -- Primary lookup: system|code pairs (the most common token search pattern).
+-- No separate system-only index: it would be a redundant strict prefix of this
+-- one, which the planner already uses for system-only lookups.
 CREATE INDEX IF NOT EXISTS idx_sp_tok_sys_code ON sp_token (tenant_id, resource_type, param_name, system, code);
--- (idx_sp_tok_system dropped: it was a strict prefix of idx_sp_tok_sys_code
---  above, which the planner already uses for system-only lookups — the separate
---  index only added write cost on the heaviest sp_* table.)
 -- Lookup by code alone when the search omits system.
-CREATE INDEX IF NOT EXISTS idx_sp_tok_code ON sp_token (tenant_id, resource_type, param_name, code) WHERE code IS NOT NULL;
--- Leading on resource_id serves the per-resource EXISTS probe of multi-parameter
--- searches and re-index deletes; param_name + system + code let the probe filter
--- the token value index-only rather than heap-fetching every sp_token row of the
--- candidate resource. (Restored from the v5 diet's (resource_id, resource_type) —
--- see the schema_version v8 note below. idx_sp_tok_system stays dropped: it is a
--- strict prefix of idx_sp_tok_sys_code and genuinely redundant for reads.)
-CREATE INDEX IF NOT EXISTS idx_sp_tok_source ON sp_token (tenant_id, resource_id, resource_type, param_name, system, code);
+CREATE INDEX IF NOT EXISTS idx_sp_tok_code     ON sp_token (tenant_id, resource_type, param_name, code) WHERE code IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sp_tok_source   ON sp_token (tenant_id, resource_id, resource_type, param_name, system, code);
+-- Recency drive for the composite token+quantity early-exit (fetchSQL's composite
+-- shape, see search.go): walk sp_token newest-first for a code, probe the other
+-- component per row, and stop after one page. INCLUDE keeps the walk (and an
+-- optional system filter) index-only.
+CREATE INDEX IF NOT EXISTS idx_sp_tok_recent   ON sp_token (tenant_id, resource_type, param_name, code, last_updated DESC) INCLUDE (resource_id, system) WHERE code IS NOT NULL;
 
--- ─── Date search index ────────────────────────────────────────────────────────
--- Stores extracted values for FHIR date / dateTime / Period / instant parameters.
--- Partial-precision dates (e.g. "2000", "2000-04") are expanded into a
+-- ─── sp_date ─────────────────────────────────────────────────────────────────
+-- FHIR date / dateTime / Period / instant parameters.
+-- Partial-precision dates ("2000", "2000-04") are expanded into a
 -- [value_low, value_high] range at write time so all 8 FHIR date comparators
--- (eq, ne, lt, gt, le, ge, sa, eb) work correctly without special casing.
+-- (eq, ne, lt, gt, le, ge, sa, eb) work without special casing.
 -- value_precision records the original granularity (YEAR|MONTH|DAY|SECOND).
 
 CREATE TABLE IF NOT EXISTS sp_date (
     id              BIGSERIAL    PRIMARY KEY,
-    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
+    tenant_id       TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id     VARCHAR(64)  NOT NULL,
     resource_type   VARCHAR(100) NOT NULL,
     param_name      VARCHAR(191) NOT NULL,
@@ -160,98 +194,88 @@ CREATE TABLE IF NOT EXISTS sp_date (
 );
 
 CREATE INDEX IF NOT EXISTS idx_sp_date_range  ON sp_date (tenant_id, resource_type, param_name, value_low, value_high);
--- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
--- deletes; param_name + range columns keep the probe index-only. (Restored from
--- the v5 diet's (resource_id, resource_type) — see the schema_version v8 note.)
 CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (tenant_id, resource_id, resource_type, param_name, value_low, value_high);
 
--- ─── Number search index ──────────────────────────────────────────────────────
--- Stores extracted values for FHIR number search parameters.
+-- ─── sp_number ───────────────────────────────────────────────────────────────
+-- FHIR number search parameters.
 -- value_low / value_high encode the implicit precision range around value so
--- that FHIR's "approximately equal" (eq) semantics work: e.g. searching for
--- 100 matches 100.4 but not 100.5.
+-- FHIR's "approximately equal" (eq) semantics work: searching 100 matches 100.4
+-- but not 100.5.
+-- last_updated is a denormalised copy of resources.last_updated, set at index
+-- time, so idx_sp_num_recent can sort candidates without a per-match lookup.
 
 CREATE TABLE IF NOT EXISTS sp_number (
     id            BIGSERIAL     PRIMARY KEY,
-    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
+    tenant_id     TEXT          NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id   VARCHAR(64)   NOT NULL,
     resource_type VARCHAR(100)  NOT NULL,
     param_name    VARCHAR(191)  NOT NULL,
     value         DECIMAL(20,6) NOT NULL,
     value_low     DECIMAL(20,6) NOT NULL,
     value_high    DECIMAL(20,6) NOT NULL,
-    -- Denormalised copy of resources.last_updated, set at index time to the exact
-    -- value written to resources. Lets the id-first fetch sort candidates straight
-    -- from idx_sp_num_range without a per-match resources lookup — see fetchSQL's
-    -- direct-drive shape.
     last_updated  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
--- Migration for pre-existing deployments: CREATE TABLE IF NOT EXISTS above does
--- NOT add last_updated to an already-created sp_number, and the covering /
--- recency indexes below reference it (idx_sp_num_recent keys on it). ADD COLUMN
--- IF NOT EXISTS is a no-op on fresh installs and backfills existing rows with the
--- DEFAULT, so both paths end up with the column before the indexes are built.
-ALTER TABLE sp_number ADD COLUMN IF NOT EXISTS last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW();
-
 -- INCLUDE (resource_id, last_updated) makes the range scan covering: the id-first
--- candidate resolve is index-only, yielding the fhir_id to join and the sort key
--- to order by without touching the heap.
+-- candidate resolve is index-only, yielding the fhir_id to join and the sort key.
 CREATE INDEX IF NOT EXISTS idx_sp_num_range  ON sp_number (tenant_id, resource_type, param_name, value_low, value_high) INCLUDE (resource_id, last_updated);
--- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
--- deletes; param_name + range columns keep the probe index-only. (Restored from
--- the v5 diet's (resource_id, resource_type) — see the schema_version v8 note.)
 CREATE INDEX IF NOT EXISTS idx_sp_num_source ON sp_number (tenant_id, resource_id, resource_type, param_name, value_low, value_high);
+CREATE INDEX IF NOT EXISTS idx_sp_num_recent ON sp_number (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id);
 
--- ─── Quantity search index ────────────────────────────────────────────────────
--- Stores extracted values for FHIR quantity search parameters.
+-- ─── sp_quantity ─────────────────────────────────────────────────────────────
+-- FHIR quantity search parameters.
 -- value / value_low / value_high hold the raw value with its precision range.
 -- canonical_value / canonical_units hold the UCUM-normalised equivalent so
--- that cross-unit comparisons work (e.g. searching "1g" matches "1000mg").
+-- cross-unit comparisons work (searching "1g" matches "1000mg").
+-- last_updated mirrors sp_number's, for idx_sp_qty_recent.
 
 CREATE TABLE IF NOT EXISTS sp_quantity (
-    id               BIGSERIAL     PRIMARY KEY,
-    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
-    resource_id      VARCHAR(64)   NOT NULL,
-    resource_type    VARCHAR(100)  NOT NULL,
-    param_name       VARCHAR(191)  NOT NULL,
-    value            DECIMAL(20,6) NOT NULL,
-    value_low        DECIMAL(20,6) NOT NULL,
-    value_high       DECIMAL(20,6) NOT NULL,
-    system           VARCHAR(255),
-    code             VARCHAR(64),
-    canonical_value  DECIMAL(20,6),
-    canonical_units  VARCHAR(64),
-    -- Denormalised copy of resources.last_updated, set at index time to the exact
-    -- value written to resources. Lets the id-first fetch sort candidates straight
-    -- from idx_sp_qty_raw without a per-match resources lookup — see fetchSQL's
-    -- direct-drive shape.
-    last_updated     TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    id              BIGSERIAL     PRIMARY KEY,
+    tenant_id       TEXT          NOT NULL DEFAULT current_setting('app.current_tenant', true),
+    resource_id     VARCHAR(64)   NOT NULL,
+    resource_type   VARCHAR(100)  NOT NULL,
+    param_name      VARCHAR(191)  NOT NULL,
+    value           DECIMAL(20,6) NOT NULL,
+    value_low       DECIMAL(20,6) NOT NULL,
+    value_high      DECIMAL(20,6) NOT NULL,
+    system          VARCHAR(255),
+    code            VARCHAR(64),
+    canonical_value DECIMAL(20,6),
+    canonical_units VARCHAR(64),
+    last_updated    TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
--- Migration for pre-existing deployments (see the sp_number note above): backfill
--- last_updated before the covering / recency indexes that reference it are built.
-ALTER TABLE sp_quantity ADD COLUMN IF NOT EXISTS last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW();
-
 -- Raw value range search (same system+code, no unit conversion needed).
 -- INCLUDE (resource_id, last_updated) makes the range scan covering so the
--- id-first candidate resolve is index-only (fhir_id to join + sort key to order).
+-- id-first candidate resolve is index-only.
 CREATE INDEX IF NOT EXISTS idx_sp_qty_raw       ON sp_quantity (tenant_id, resource_type, param_name, value_low, value_high, system, code) INCLUDE (resource_id, last_updated);
--- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
--- deletes. buildQuantityExists filters on value_low/value_high plus optional
--- system/code, so those trail param_name to keep the probe index-only — matching
--- the date/number _source indexes. (The pre-v5 form was (resource_id,
--- resource_type, param_name) with no value columns; widened here for index-only
--- parity. See the schema_version v8 note.)
+-- buildQuantityExists filters on value_low/value_high plus optional system/code,
+-- so those trail param_name to keep the probe index-only.
 CREATE INDEX IF NOT EXISTS idx_sp_qty_source    ON sp_quantity (tenant_id, resource_id, resource_type, param_name, value_low, value_high, system, code);
 -- Canonical search (cross-unit comparison via UCUM normalisation).
-CREATE INDEX IF NOT EXISTS idx_sp_qty_canonical ON sp_quantity (tenant_id, resource_type, param_name, canonical_value, canonical_units)
-    WHERE canonical_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sp_qty_canonical ON sp_quantity (tenant_id, resource_type, param_name, canonical_value, canonical_units) WHERE canonical_value IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sp_qty_recent    ON sp_quantity (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id, system, code);
 
--- ─── URI search index ─────────────────────────────────────────────────────────
--- Stores extracted values for FHIR uri search parameters (url, profile, etc.).
+-- Range-overlap GiST index for bounded quantity searches (eq / ne / ge / le),
+-- reachable only through the numrange && operator. Those prefixes are interval
+-- overlap — value_low <= searchHigh AND value_high >= searchLow — which as two
+-- independent numeric bounds can only ride the btree value indexes above; a dense
+-- bounded window (e.g. value-quantity=ge10&le140) still had to scan-and-filter a
+-- whole (tenant, type, param) partition. buildQuantityExists emits the predicate
+-- as numrange(s.value_low, s.value_high, '[]') && numrange(searchLow, searchHigh,
+-- '[]'); the index expression below must stay byte-for-byte identical to that
+-- stored numrange, or the planner will not match it. gt/lt stay scalar (strict,
+-- not overlap) and keep using the btree value indexes.
+-- The leading (tenant_id, resource_type, param_name) equality columns are varchar,
+-- which have no default gist opclass, so the multicolumn GiST needs btree_gist.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE INDEX IF NOT EXISTS idx_sp_qty_range_gist ON sp_quantity
+    USING gist (tenant_id, resource_type, param_name, numrange(value_low, value_high, '[]'));
+
+-- ─── sp_uri ──────────────────────────────────────────────────────────────────
+-- FHIR uri search parameters (url, profile, etc.).
 -- Supports exact match and the :below modifier (prefix / hierarchy match).
 
 CREATE TABLE IF NOT EXISTS sp_uri (
@@ -267,21 +291,18 @@ CREATE TABLE IF NOT EXISTS sp_uri (
 CREATE INDEX IF NOT EXISTS idx_sp_uri_exact  ON sp_uri (tenant_id, resource_type, param_name, value);
 -- text_pattern_ops enables efficient LIKE 'prefix%' for the :below modifier.
 CREATE INDEX IF NOT EXISTS idx_sp_uri_prefix ON sp_uri (tenant_id, resource_type, param_name, value text_pattern_ops);
--- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
--- deletes; param_name + value keep the probe index-only. (Restored from the v5
--- diet's (resource_id, resource_type) — see the schema_version v8 note.)
 CREATE INDEX IF NOT EXISTS idx_sp_uri_source ON sp_uri (tenant_id, resource_id, resource_type, param_name, value);
 
--- ─── Reference search index ───────────────────────────────────────────────────
--- Stores extracted values for FHIR reference search parameters.
--- Also used for _include / _revinclude and $everything traversal.
+-- ─── sp_reference ────────────────────────────────────────────────────────────
+-- FHIR reference search parameters. Also used for _include / _revinclude and
+-- $everything traversal.
 -- target_url holds the literal URL when the reference is external (not local).
 -- identifier_* columns support the :identifier modifier (search by Identifier
 -- instead of resource id).
 
 CREATE TABLE IF NOT EXISTS sp_reference (
     id                BIGSERIAL    PRIMARY KEY,
-    tenant_id     TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
+    tenant_id         TEXT         NOT NULL DEFAULT current_setting('app.current_tenant', true),
     resource_id       VARCHAR(64)  NOT NULL,
     resource_type     VARCHAR(100) NOT NULL,
     param_name        VARCHAR(191) NOT NULL,
@@ -295,20 +316,15 @@ CREATE TABLE IF NOT EXISTS sp_reference (
     FOREIGN KEY (tenant_id, resource_id, resource_type) REFERENCES resources (tenant_id, fhir_id, resource_type) ON DELETE CASCADE
 );
 
--- Serves the per-resource EXISTS probe of multi-parameter searches and re-index
--- deletes; param_name + target_id let the probe resolve reference-by-source
--- predicates index-only. (Restored from the v5 diet's (resource_id, resource_type)
--- — see the schema_version v8 note below.)
 CREATE INDEX IF NOT EXISTS idx_sp_ref_source      ON sp_reference (tenant_id, resource_id, resource_type, param_name, target_id);
--- Used when searching by target (e.g. ?patient=123): leading on target_id
--- serves bare-id lookups; extra columns allow the predicate to resolve index-only.
+-- Search by target (e.g. ?patient=123): leading on target_id serves bare-id
+-- lookups; the trailing columns let the predicate resolve index-only.
 CREATE INDEX IF NOT EXISTS idx_sp_ref_target_full ON sp_reference (tenant_id, target_id, target_type, param_name, resource_type, resource_id);
--- Used for the :identifier modifier (find references by Identifier value).
-CREATE INDEX IF NOT EXISTS idx_sp_ref_ident       ON sp_reference (tenant_id, target_type, identifier_system, identifier_value)
-    WHERE identifier_value IS NOT NULL;
+-- The :identifier modifier (find references by Identifier value).
+CREATE INDEX IF NOT EXISTS idx_sp_ref_ident       ON sp_reference (tenant_id, target_type, identifier_system, identifier_value) WHERE identifier_value IS NOT NULL;
 
--- ─── Coordinates search index ─────────────────────────────────────────────────
--- Stores lat/lng for the Location.near search parameter.
+-- ─── sp_coords ───────────────────────────────────────────────────────────────
+-- lat/lng for the Location.near search parameter.
 -- For heavy geospatial workloads, consider replacing lat/lng with a
 -- PostGIS geometry(Point,4326) column and a GIST index.
 
@@ -325,24 +341,28 @@ CREATE TABLE IF NOT EXISTS sp_coords (
 
 CREATE INDEX IF NOT EXISTS idx_sp_coords ON sp_coords (tenant_id, resource_type, param_name, latitude, longitude);
 
--- ─── Search parameter definitions ────────────────────────────────────────────
--- Registry of all known search parameters for each resource type.
--- Populated at server startup from the embedded FHIR R4 base spec (CSV) and
--- any loaded Implementation Guide packages.
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 4. Registry & reference data
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ─── search_param_definitions ────────────────────────────────────────────────
+-- Registry of all known search parameters for each resource type. Populated at
+-- startup from the embedded FHIR R4 base spec (CSV) and any loaded IG packages.
 -- ig_source: '' = base FHIR R4, 'user' = custom SearchParameter resource,
 --            'name@version' = sourced from a specific IG package.
 -- components_json: composite search parameter component expressions (JSON array).
 
 CREATE TABLE IF NOT EXISTS search_param_definitions (
-    id               SERIAL       PRIMARY KEY,
-    resource_type    VARCHAR(191) NOT NULL,
-    param_name       VARCHAR(191) NOT NULL,
-    param_type       VARCHAR(32)  NOT NULL,
-    fhirpath_expr    TEXT         NOT NULL,
-    is_custom        BOOLEAN      NOT NULL DEFAULT FALSE,
-    ig_source        TEXT         NOT NULL DEFAULT '',
-    target_types     TEXT         NOT NULL DEFAULT '',
-    components_json  TEXT         NOT NULL DEFAULT '',
+    id              SERIAL       PRIMARY KEY,
+    resource_type   VARCHAR(191) NOT NULL,
+    param_name      VARCHAR(191) NOT NULL,
+    param_type      VARCHAR(32)  NOT NULL,
+    fhirpath_expr   TEXT         NOT NULL,
+    is_custom       BOOLEAN      NOT NULL DEFAULT FALSE,
+    ig_source       TEXT         NOT NULL DEFAULT '',
+    target_types    TEXT         NOT NULL DEFAULT '',
+    components_json TEXT         NOT NULL DEFAULT '',
     UNIQUE (resource_type, param_name)
 );
 
@@ -373,13 +393,14 @@ CREATE TABLE IF NOT EXISTS ig_profiles (
     UNIQUE (profile_url)
 );
 
--- ─── Base FHIR R4 StructureDefinitions ────────────────────────────────────────
--- The core FHIR R4 resource StructureDefinitions (kind=resource,
+-- ─── base_definitions ────────────────────────────────────────────────────────
+-- Core FHIR R4 resource StructureDefinitions (kind=resource,
 -- derivation=specialization) shipped with the server and loaded at startup (see
--- internal/basedef). They let the server validate resources against the base
--- spec even when no profile is supplied. Like ig_profiles this is reference data,
--- not PHI, and is identical across tenants — so it carries no tenant_id and is
--- intentionally excluded from the Row-Level Security policies below.
+-- internal/basedef). They let the server validate resources against the base spec
+-- even when no profile is supplied. Like ig_profiles this is reference data, not
+-- PHI, and is identical across tenants — so it carries no tenant_id and is
+-- intentionally excluded from the Row-Level Security policies in section 7.
+
 CREATE TABLE IF NOT EXISTS base_definitions (
     resource_type TEXT        NOT NULL PRIMARY KEY,
     sd_url        TEXT        NOT NULL DEFAULT '',
@@ -387,7 +408,7 @@ CREATE TABLE IF NOT EXISTS base_definitions (
     loaded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- ─── FHIR Terminology: closure tables ─────────────────────────────────────────
+-- ─── FHIR Terminology: closure tables ────────────────────────────────────────
 -- Support the $closure operation, which maintains a transitive closure table of
 -- subsumption relationships between coded concepts. A closure context groups
 -- related concepts; ClosureDeltaTable records each subsumes/subsumed-by pair.
@@ -422,9 +443,14 @@ CREATE TABLE IF NOT EXISTS "ClosureDeltaTable" (
     UNIQUE ("CONTEXT_ID", "SUBSUMES_ID", "SUBSUMED_ID")
 );
 
--- ─── Planner statistics ───────────────────────────────────────────────────────
--- Raise statistics targets for high-cardinality columns so the planner
--- produces accurate row-count estimates for multi-param searches.
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 5. Planner statistics
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Populated by ANALYZE (autoanalyze covers this after the bulk import).
+
+-- Raise statistics targets for high-cardinality columns so the planner produces
+-- accurate row-count estimates for multi-param searches.
 ALTER TABLE sp_token     ALTER COLUMN code          SET STATISTICS 1000;
 ALTER TABLE sp_token     ALTER COLUMN system        SET STATISTICS 1000;
 ALTER TABLE sp_token     ALTER COLUMN resource_type SET STATISTICS 1000;
@@ -441,7 +467,6 @@ ALTER TABLE sp_reference ALTER COLUMN param_name    SET STATISTICS 1000;
 -- at the first page: ~966ms vs ~15ms on the perf dataset. MCV/dependencies over
 -- the correlated columns correct the estimate so the planner picks the ordered
 -- scan for dense codes and the id-first-style materialize for sparse ones.
--- Populated by ANALYZE (autoanalyze covers this after the bulk import).
 CREATE STATISTICS IF NOT EXISTS stx_sp_token_rt_param_code (dependencies, ndistinct, mcv)
     ON resource_type, param_name, code FROM sp_token;
 
@@ -452,21 +477,19 @@ CREATE STATISTICS IF NOT EXISTS stx_sp_token_rt_param_code (dependencies, ndisti
 -- independent and badly UNDER-estimates a dense combination: Encounter class=AMB
 -- (62k rows) was estimated at 593, so it materialised + sorted every match and
 -- joined resources per row (~2.7s) instead of the abort-early ordered scan
--- (~0.7ms). Adding system to the multivariate stat corrects the estimate so the
--- planner takes the ordered early-exit for dense system|code tokens and keeps
--- the id-first materialize for sparse ones. Populated by ANALYZE.
+-- (~0.7ms). Adding system to the multivariate stat corrects the estimate.
 CREATE STATISTICS IF NOT EXISTS stx_sp_token_rt_param_sys_code (dependencies, ndistinct, mcv)
     ON resource_type, param_name, system, code FROM sp_token;
 
--- ─── Autovacuum tuning for high-churn tables ─────────────────────────────────
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 6. Autovacuum tuning for high-churn tables
+-- ═══════════════════════════════════════════════════════════════════════════
 -- Default autovacuum_vacuum_scale_factor=0.20 means PostgreSQL waits until 20%
--- of a table is dead before cleaning up. On tables with millions of rows that
--- is millions of dead tuples — causing index bloat, planner misstimation, and
--- the throughput degradation visible after ~500 s in all load test runs.
--- Tighten to 2% so autovacuum stays ahead of write-heavy workloads.
---
--- These ALTER TABLE SET (...) statements are idempotent: safe to re-run on
--- an existing database.
+-- of a table is dead before cleaning up. On tables with millions of rows that is
+-- millions of dead tuples — causing index bloat, planner misestimation, and the
+-- throughput degradation visible after ~500s in load test runs. Tighten to 2% so
+-- autovacuum stays ahead of write-heavy workloads.
 
 ALTER TABLE resources SET (
     autovacuum_vacuum_scale_factor  = 0.02,
@@ -478,8 +501,8 @@ ALTER TABLE resource_history SET (
     autovacuum_analyze_scale_factor = 0.01
 );
 
--- sp_* tables are DELETE+INSERT heavy on every UPDATE; keep them lean so
--- index bloat does not accumulate between vacuum cycles.
+-- sp_* tables are DELETE+INSERT heavy on every UPDATE; keep them lean so index
+-- bloat does not accumulate between vacuum cycles.
 ALTER TABLE sp_string    SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.01);
 ALTER TABLE sp_token     SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.01);
 ALTER TABLE sp_date      SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.01);
@@ -489,28 +512,22 @@ ALTER TABLE sp_uri       SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_
 ALTER TABLE sp_reference SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.01);
 ALTER TABLE sp_coords    SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.01);
 
--- ─── Stamp schema version ─────────────────────────────────────────────────────
 
--- v5: ingest write-amplification diet — slimmed the 7 sp_* _source indexes to
--- (resource_id, resource_type) and dropped redundant idx_sp_tok_system. Fresh
--- installs get the lean form; existing DBs need a migration to DROP+recreate
--- (CREATE INDEX IF NOT EXISTS won't alter an index that already exists).
-INSERT INTO schema_version (version) VALUES (5) ON CONFLICT DO NOTHING;
-
--- ─── Multi-tenancy: Row-Level Security ────────────────────────────────────────
--- Every PHI-bearing table (resources, resource_history, sp_*) carries a
--- tenant_id column (declared inline in the definitions above) that defaults to
--- the app.current_tenant runtime setting the server applies per request. Their
--- primary / foreign keys and the resource_history version-uniqueness all lead
--- with tenant_id, so two tenants may hold resources with the same id. The
--- global configuration tables (search_param_definitions, ig_*, the closure
--- tables, schema_version) are intentionally SHARED across tenants and carry no
--- tenant_id.
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 7. Multi-tenancy: Row-Level Security
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Every PHI-bearing table (resources, resource_history, sp_*) carries a tenant_id
+-- column that defaults to the app.current_tenant runtime setting the server applies
+-- per request. Their primary / foreign keys and the resource_history version-
+-- uniqueness all lead with tenant_id, so two tenants may hold resources with the
+-- same id. The global configuration tables (search_param_definitions, ig_*, the
+-- closure tables, base_definitions, schema_version) are intentionally SHARED across
+-- tenants and carry no tenant_id.
 --
--- Isolation is enforced by Row-Level Security: each policy restricts rows to
--- the current tenant. FORCE makes the policy apply to the table owner too. An
--- unset tenant fails CLOSED — NULL matches no rows and violates the NOT NULL
--- tenant_id on write.
+-- Isolation is enforced by Row-Level Security: each policy restricts rows to the
+-- current tenant. FORCE makes the policy apply to the table owner too. An unset
+-- tenant fails CLOSED — NULL matches no rows and violates the NOT NULL tenant_id
+-- on write.
 --
 -- NOTE: the server (and any tooling that touches these tables at runtime) MUST
 -- connect as a NON-superuser role — superusers and roles with BYPASSRLS ignore
@@ -535,50 +552,29 @@ BEGIN
 END
 $rls$;
 
-INSERT INTO schema_version (version) VALUES (6) ON CONFLICT DO NOTHING;
--- v7: add base_definitions (core FHIR R4 StructureDefinitions for base validation)
-INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;
 
--- v8: revert the v5 _source-index diet that regressed multi-parameter search.
--- Multi-param searches are built as correlated `EXISTS (SELECT 1 FROM sp_* s
--- WHERE s.resource_id = r.fhir_id AND s.resource_type = … AND s.param_name = …
--- AND <value predicate>)` (see internal/store/search.go). v5 slimmed the 7 sp_*
--- _source indexes to (tenant_id, resource_id, resource_type), dropping param_name
--- and the value columns. That forced the per-resource EXISTS probe to scan every
--- sp_* row of a candidate resource and heap-fetch each to re-check param_name and
--- value — the drastic search slowdown reported after 2671286. Restored above to
--- the pre-v5 composite forms (param_name + value columns, tenant_id-led) so the
--- probe narrows to the parameter and resolves its value predicate index-only.
--- idx_sp_tok_system stays dropped (a redundant strict prefix of idx_sp_tok_sys_code).
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 8. LEAKPROOF operators
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Under Row-Level Security the sp_* tables are security barriers (FORCE ROW LEVEL
+-- SECURITY, section 7): a user WHERE qual is evaluated *inside* the index scan (as
+-- an index cond) only if EVERY function it calls is LEAKPROOF; otherwise it is held
+-- back and applied as a post-filter above the barrier. PostgreSQL ships text and
+-- date/timestamptz comparisons LEAKPROOF but NOT the numeric or range ones used by
+-- quantity/number search, so those must be marked here.
 --
--- Fresh installs get the restored indexes above. EXISTING databases are NOT
--- altered by CREATE INDEX IF NOT EXISTS (it won't rebuild an index that already
--- exists), so each idx_sp_*_source must be dropped and recreated, e.g.:
---   DROP  INDEX CONCURRENTLY IF EXISTS idx_sp_str_source;
---   CREATE INDEX CONCURRENTLY idx_sp_str_source
---       ON sp_string (tenant_id, resource_id, resource_type, param_name, value_lower);
--- (repeat for tok/date/num/qty/uri/ref with the column lists above).
-INSERT INTO schema_version (version) VALUES (8) ON CONFLICT DO NOTHING;
+-- Both blocks require superuser: only a superuser may set LEAKPROOF. Each is
+-- wrapped so a non-super DDL role (or managed Postgres with no superuser, e.g.
+-- Azure Flexible Server) still applies the rest of the schema — the optimization
+-- is skipped with a notice and those searches fall back to the correct, slower
+-- post-filter path.
 
--- v9: mark numeric comparison operators LEAKPROOF so quantity/number range and
--- equality predicates push into the sp_quantity/sp_number indexes under RLS.
---
--- With Row-Level Security the sp_* tables are security barriers: a user WHERE
--- qual is evaluated *inside* the index scan (as an index cond) only if its
--- operator is LEAKPROOF; otherwise it is held back and applied as a post-filter
--- above the barrier. PostgreSQL ships text and date/timestamptz comparisons
--- LEAKPROOF, but NOT the numeric ones. So `value_low > $1` on sp_quantity
--- (numeric(20,6)) could not use the (tenant_id, resource_type, param_name,
--- value_low, …) index bound — every quantity/number search scanned the entire
+-- Scalar numeric comparisons (value_low > $1 etc.) for number/quantity range and
+-- equality searches. Without this every such search scanned the whole
 -- (tenant, type, param) partition and filtered value_low in memory (~50ms/query
--- on the perf dataset, and far worse under concurrency where it spawned parallel
--- seq scans). numeric comparison operators are pure arithmetic and do not leak
--- argument values via errors or side channels, so marking them LEAKPROOF is safe.
---
--- Requires superuser: only a superuser may set LEAKPROOF. Wrapped so a non-super
--- DDL role (or managed Postgres with no superuser, e.g. Azure Flexible Server)
--- still applies the rest of the schema — the optimization is skipped with a
--- notice and those searches fall back to the correct, slower post-filter path.
+-- on the perf dataset, worse under concurrency where it spawned parallel seq
+-- scans). numeric comparisons are pure arithmetic and do not leak argument values
+-- via errors or side channels, so marking them LEAKPROOF is safe.
 DO $leakproof$
 BEGIN
     ALTER FUNCTION numeric_eq(numeric, numeric) LEAKPROOF;
@@ -592,105 +588,24 @@ EXCEPTION
 END
 $leakproof$;
 
-INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;
-
--- v10: recency covering indexes on the numeric sp_* tables, ordered by
--- last_updated DESC, for the early-exit id-first fetch (directDriveSQL).
+-- Range overlap for the bounded quantity search GiST index (idx_sp_qty_range_gist).
+-- The predicate is  numrange(s.value_low, s.value_high, '[]') && numrange($lo, $hi,
+-- '[]'), so both the && operator (range_overlaps) AND the numrange constructor that
+-- runs per row must be leakproof for && to become a GiST Index Cond under RLS —
+-- verified on PostgreSQL 15 that marking only range_overlaps leaves && a recheck
+-- filter. Leaving it half-done would also strand the idx_sp_qty_recent early-exit,
+-- whose value filter would no longer push into the scan.
 --
--- The value indexes above (idx_sp_qty_raw / idx_sp_num_range) are ordered by
--- value, so a search sorted by recency had to read the entire match set and
--- top-N sort it — fine for a sparse predicate, but for a DENSE one (e.g.
--- value-quantity=le140 matching ~500k rows) that was a multi-hundred-ms
--- materialise-and-sort. Ordering the index by last_updated DESC lets the
--- planner walk it newest-first, apply the value predicate from the INCLUDE'd
--- columns, and stop after one page (~1ms), while a sparse/empty predicate still
--- uses the value index. The planner chooses between the two per bound value
--- (force_custom_plan) from the single sp_* table's own statistics — no
--- application-level plan forcing.
-CREATE INDEX IF NOT EXISTS idx_sp_qty_recent ON sp_quantity (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id, system, code);
-CREATE INDEX IF NOT EXISTS idx_sp_num_recent ON sp_number   (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id);
-
-INSERT INTO schema_version (version) VALUES (10) ON CONFLICT DO NOTHING;
-
--- v11: recency covering index on sp_token, ordered by last_updated DESC, for the
--- composite early-exit drive (fetchSQL's composite shape, see search.go).
---
--- A composite token+quantity search (e.g. code-value-quantity) drives candidate
--- resolution from the selective token component, then filters by the quantity
--- component. Without a recency-ordered token index the drive had to resolve the
--- whole intersection and top-N sort it — cheap for a selective code, but for a
--- common code with a loose value bound (e.g. body-weight code + value>80, an
--- 8k-row intersection) that was a multi-second materialise-and-sort that also
--- tripped a parallel hash join. Ordering the index by last_updated DESC lets the
--- drive walk sp_token newest-first for the code, probe the quantity component
--- per row, and stop after one page. INCLUDE (resource_id, system) keeps the walk
--- (and an optional system filter) index-only.
---
--- Migration for pre-existing deployments (mirrors the sp_number / sp_quantity
--- v10 note): ADD COLUMN before the recency index that references it. Existing
--- rows take the migration-time default; the exact resources.last_updated is
--- written on the next re-index, matching how the numeric tables were populated.
-ALTER TABLE sp_token ADD COLUMN IF NOT EXISTS last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW();
-CREATE INDEX IF NOT EXISTS idx_sp_tok_recent ON sp_token (tenant_id, resource_type, param_name, code, last_updated DESC) INCLUDE (resource_id, system) WHERE code IS NOT NULL;
-
-INSERT INTO schema_version (version) VALUES (11) ON CONFLICT DO NOTHING;
-
--- v12: range-overlap GiST index on sp_quantity for the bounded quantity searches
--- (eq / ne / ge / le), reachable only through the numrange && operator.
---
--- Those prefixes are interval overlap — value_low <= searchHigh AND value_high >=
--- searchLow — but expressed as two independent numeric bounds the predicate can
--- only ride the btree value indexes (idx_sp_qty_raw / idx_sp_qty_recent). A dense
--- bounded window (e.g. value-quantity=ge10&le140 covering a large slice of one
--- (tenant, type, param) partition) still had to scan-and-filter that whole
--- partition. A GiST index over the stored interval answers the same overlap with
--- a range probe. buildQuantityExists now emits the predicate as
--- numrange(s.value_low, s.value_high, '[]') && numrange(searchLow, searchHigh, '[]');
--- the index expression below must stay byte-for-byte identical to that stored
--- numrange, or the planner will not match it. gt/lt stay scalar (strict, not
--- overlap) and keep using the btree value indexes.
---
--- The leading (tenant_id, resource_type, param_name) equality columns are varchar,
--- which have no default gist opclass, so the multicolumn GiST needs btree_gist.
-CREATE EXTENSION IF NOT EXISTS btree_gist;
-CREATE INDEX IF NOT EXISTS idx_sp_qty_range_gist ON sp_quantity
-    USING gist (tenant_id, resource_type, param_name, numrange(value_low, value_high, '[]'));
--- Production build note: on an existing large sp_quantity, build this out of band
--- with CREATE INDEX CONCURRENTLY before deploying the paired search.go change —
--- CONCURRENTLY cannot run inside schema.sql's single implicit transaction:
---   CREATE INDEX CONCURRENTLY idx_sp_qty_range_gist ON sp_quantity
---       USING gist (tenant_id, resource_type, param_name,
---                   numrange(value_low, value_high, '[]'));
-
--- LEAKPROOF the two functions the overlap predicate is built from, so it reaches
--- the GiST index under RLS. Under the FORCE ROW LEVEL SECURITY barrier on the
--- sp_* tables (see the tenant_isolation policy above) a qual is only pushed below
--- the barrier — and thus eligible to become an index cond — if EVERY function it
--- calls is LEAKPROOF; otherwise it is held back as a post-filter above the
--- barrier. This is the same barrier the v9 numeric-operator marking addressed. The
--- predicate is  numrange(s.value_low, s.value_high, '[]') && numrange($lo, $hi, '[]'),
--- so both the && operator (range_overlaps) AND the numrange constructor that runs
--- per row on value_low/value_high must be leakproof. Verified: with only
--- range_overlaps marked, the && stays a recheck filter under RLS and the GiST
--- index is never used to narrow by range (measured on PostgreSQL 15); marking both
--- pushes && into the GiST Index Cond. Leaving it half-done would also strand the
--- v10 recency early-exit, whose value filter over idx_sp_qty_recent would no longer
--- push into the scan.
---
--- Safety. range_overlaps is pure bound arithmetic and cannot leak. numrange is
--- less obvious: its 3-arg constructor raises "range lower bound must be less than
--- or equal to range upper bound" when lower > upper, and an argument-dependent
--- error is normally a side channel that disqualifies LEAKPROOF. It is safe HERE
--- because the expression index above computes the very same
--- numrange(value_low, value_high, '[]') for every row at write time — a row that
--- would make the constructor throw cannot be inserted while the index exists — so
--- the query-time constructor never errors on stored data. Caveat: LEAKPROOF is a
--- global property of the function, so it relaxes numrange() everywhere; this schema
--- uses numrange only for this index, but a future RLS table that constructs
--- numrange over unconstrained numerics would inherit the relaxed barrier. Same
--- superuser caveat / defensive wrapper as v9: a non-super DDL role still applies
--- the rest of the schema, and these searches fall back to the correct, slower
--- post-filter path.
+-- Safety. range_overlaps is pure bound arithmetic and cannot leak. numrange is less
+-- obvious: its 3-arg constructor raises "range lower bound must be less than or
+-- equal to range upper bound" when lower > upper, and an argument-dependent error
+-- is normally a side channel that disqualifies LEAKPROOF. It is safe HERE because
+-- idx_sp_qty_range_gist computes the very same numrange(value_low, value_high, '[]')
+-- for every row at write time — a row that would make the constructor throw cannot
+-- be inserted while the index exists — so the query-time constructor never errors
+-- on stored data. Caveat: LEAKPROOF is a global property, so this relaxes numrange
+-- everywhere; this schema uses numrange only for that index, but a future RLS table
+-- constructing numrange over unconstrained numerics would inherit the relaxed barrier.
 DO $leakproof_range$
 BEGIN
     ALTER FUNCTION range_overlaps(anyrange, anyrange) LEAKPROOF;
@@ -700,5 +615,3 @@ EXCEPTION
         RAISE NOTICE 'skipping LEAKPROOF on range_overlaps/numrange (requires superuser); bounded quantity searches under RLS will use a slower post-filter';
 END
 $leakproof_range$;
-
-INSERT INTO schema_version (version) VALUES (12) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## What

Reorganizes `internal/db/schema.sql` so each table is defined together with all of its own indexes, and the file is split into eight clearly-labeled sections:

1. Schema version table
2. Core resource storage (`resources`, `resource_history`)
3. Search-parameter indexes (`sp_*`)
4. Registry & reference data (`search_param_definitions`, `ig_*`, `base_definitions`, closure tables)
5. Planner statistics
6. Autovacuum tuning
7. Row-Level Security
8. LEAKPROOF operators

## Why

Table and index definitions were scattered — the recency covering indexes (`idx_sp_num_recent`, `idx_sp_qty_recent`, `idx_sp_tok_recent`) and the range-overlap GiST index (`idx_sp_qty_range_gist`) with its `btree_gist` extension lived down in the old version-stamp section, far from the tables they belong to. They now sit beside those tables.

This treats the file purely as a **fresh-database schema — no migration machinery** (the DB is not used by anyone yet):

- The `last_updated` columns are declared inline in `sp_token` / `sp_number` / `sp_quantity`, so the three `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration statements are dropped.
- The per-version `schema_version` stamps (v5–v12) collapse to a single baseline `INSERT … VALUES (1)`.
- The version-history section — with its `DROP`+recreate / `CREATE INDEX CONCURRENTLY` rebuild guidance for pre-existing databases — is removed.
- Comments lose the "for pre-existing deployments" narrative and the `vN` cross-references, keeping all functional rationale.
- The two `LEAKPROOF` `DO` blocks are collected into one section.
- Fixed misaligned `tenant_id` columns in `sp_date`, `sp_quantity`, `sp_reference`.
- Corrected the header to require PostgreSQL **14+** (`resource_json` uses `COMPRESSION lz4`).

## No change to any object definition

Diffed against `main`: all **34** index definitions, every table's columns, the `btree_gist` extension, both `CREATE STATISTICS`, the RLS policy, and the numeric/range `LEAKPROOF` markings are unchanged. Only removed statements are the three `ADD COLUMN` migrations and the six redundant version stamps; everything else differs only in placement, alignment, and comments.

## Testing

`go test -tags=integration ./internal/db/` passes — fresh table creation, idempotent re-run, and the `search_param_definitions` column check, all against a real `postgres:16` container via the actual `db.CreateTables` path.