### PR TITLE
fix(fhirpath): resolve bare choice-type fields

### DIFF
--- a/internal/fhirpath/eval.go
+++ b/internal/fhirpath/eval.go
@@ -310,11 +310,10 @@ func applyNode(n node, input any) ([]any, error) {
 func traverseField(input any, field string) []any {
 	switch v := input.(type) {
 	case map[string]any:
-		val, ok := v[field]
-		if !ok {
-			return nil
+		if val, ok := v[field]; ok {
+			return flatten(val)
 		}
-		return flatten(val)
+		return traverseChoiceField(v, field)
 	case []any:
 		var results []any
 		for _, item := range v {
@@ -323,6 +322,30 @@ func traverseField(input any, field string) []any {
 		return results
 	}
 	return nil
+}
+
+// FHIR R4 choice fields replace [x] with the title-cased concrete datatype, such as effectiveDateTime.
+// https://hl7.org/fhir/R4/datatypes.html
+var fhirChoiceTypeSuffixes = [...]string{
+	"Base64Binary", "Boolean", "Canonical", "Code", "Date", "DateTime",
+	"Decimal", "Id", "Instant", "Integer", "Markdown", "Oid",
+	"PositiveInt", "String", "Time", "UnsignedInt", "Uri", "Url", "Uuid",
+	"Address", "Age", "Annotation", "Attachment", "CodeableConcept", "Coding",
+	"ContactPoint", "Count", "Distance", "Duration", "HumanName", "Identifier",
+	"Money", "Period", "Quantity", "Range", "Ratio", "Reference",
+	"SampledData", "Signature", "Timing", "ContactDetail", "Contributor",
+	"DataRequirement", "Expression", "ParameterDefinition", "RelatedArtifact",
+	"TriggerDefinition", "UsageContext", "Dosage", "Meta",
+}
+
+func traverseChoiceField(resource map[string]any, field string) []any {
+	var results []any
+	for _, suffix := range fhirChoiceTypeSuffixes {
+		if val, ok := resource[field+suffix]; ok {
+			results = append(results, flatten(val)...)
+		}
+	}
+	return results
 }
 
 // flatten unwraps a top-level array into individual elements.

--- a/internal/fhirpath/eval_test.go
+++ b/internal/fhirpath/eval_test.go
@@ -17,6 +17,7 @@
 package fhirpath_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/wso2/fhir-server/internal/fhirpath"
@@ -266,6 +267,54 @@ func TestEvaluatePolymorphic_NoOfType_PassThrough(t *testing.T) {
 	got, err := fhirpath.EvaluatePolymorphic("Observation.status", r)
 	assertNoErr(t, err)
 	assertStrings(t, got, "final")
+}
+
+func TestEvaluatePolymorphic_BareChoiceField(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource map[string]any
+		want     any
+	}{
+		{
+			name:     "dateTime",
+			resource: map[string]any{"effectiveDateTime": "2026-06-30T06:45:00Z"},
+			want:     "2026-06-30T06:45:00Z",
+		},
+		{
+			name:     "period",
+			resource: map[string]any{"effectivePeriod": map[string]any{"start": "2026-06-30"}},
+			want:     map[string]any{"start": "2026-06-30"},
+		},
+		{
+			name:     "timing",
+			resource: map[string]any{"effectiveTiming": map[string]any{"event": []any{"2026-06-30"}}},
+			want:     map[string]any{"event": []any{"2026-06-30"}},
+		},
+		{
+			name:     "instant",
+			resource: map[string]any{"effectiveInstant": "2026-06-30T06:45:00Z"},
+			want:     "2026-06-30T06:45:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fhirpath.EvaluatePolymorphic("Observation.effective", tt.resource)
+			assertNoErr(t, err)
+			if len(got) != 1 || !reflect.DeepEqual(got[0], tt.want) {
+				t.Fatalf("got %v, want [%v]", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluatePolymorphic_BareChoiceFieldDoesNotUseArbitraryPrefix(t *testing.T) {
+	r := map[string]any{"valueSet": "http://example.org/ValueSet/test"}
+	got, err := fhirpath.EvaluatePolymorphic("Observation.value", r)
+	assertNoErr(t, err)
+	if len(got) != 0 {
+		t.Fatalf("got %v, want no match", got)
+	}
 }
 
 func TestEvaluatePolymorphic_MultipleOfType(t *testing.T) {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1231,6 +1231,66 @@ func TestSearch_ByQuantityParam(t *testing.T) {
 	}
 }
 
+func TestSearch_ObservationDateChoice(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	dateTimeObservation, err := s.Create(ctx, "Observation", map[string]any{
+		"resourceType":      "Observation",
+		"status":            "final",
+		"code":              map[string]any{"text": "dateTime observation"},
+		"effectiveDateTime": "2026-06-30T06:45:00Z",
+	})
+	if err != nil {
+		t.Fatalf("Create dateTime Observation: %v", err)
+	}
+	periodObservation, err := s.Create(ctx, "Observation", map[string]any{
+		"resourceType": "Observation",
+		"status":       "final",
+		"code":         map[string]any{"text": "period observation"},
+		"effectivePeriod": map[string]any{
+			"start": "2026-07-10T00:00:00Z",
+			"end":   "2026-07-12T00:00:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create Period Observation: %v", err)
+	}
+
+	exact, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"date": {"2026-06-30"}},
+	})
+	if err != nil {
+		t.Fatalf("Search exact Observation date: %v", err)
+	}
+	if exact.Total != 1 || exact.Entries[0]["id"] != dateTimeObservation["id"] {
+		t.Fatalf("exact date: got entries %v, want only %v", exact.Entries, dateTimeObservation["id"])
+	}
+
+	period, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"date": {"2026-07-11"}},
+	})
+	if err != nil {
+		t.Fatalf("Search Observation period date: %v", err)
+	}
+	if period.Total != 1 || period.Entries[0]["id"] != periodObservation["id"] {
+		t.Fatalf("period date: got entries %v, want only %v", period.Entries, periodObservation["id"])
+	}
+
+	since, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"date": {"ge2026-07-01"}},
+	})
+	if err != nil {
+		t.Fatalf("Search prefixed Observation date: %v", err)
+	}
+	if since.Total != 1 || since.Entries[0]["id"] != periodObservation["id"] {
+		t.Fatalf("prefixed date: got entries %v, want only %v", since.Entries, periodObservation["id"])
+	}
+}
+
 func TestSearch_MissingModifier(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- resolve bare FHIRPath choice fields through their concrete FHIR R4 JSON names
- preserve exact field lookup before attempting choice-type resolution
- cover `Observation.effective[x]` variants and guard against arbitrary prefix matches
- verify `Observation?date=` indexing and searches against PostgreSQL

## Root cause

The standard Observation date search expression is `Observation.effective`, but FHIR JSON stores the selected choice as `effectiveDateTime`, `effectivePeriod`, `effectiveTiming`, or `effectiveInstant`. The evaluator only expanded choice fields when `.ofType(...)` was present, so the bare expression looked for a nonexistent `effective` JSON key. No value reached the date indexer, leaving searches with no `sp_date` row to match.

## Impact

Newly created or updated resources using bare choice-type search expressions are indexed through their concrete JSON fields. This fixes Observation date searches for dateTime, instant, and Period values. Existing resources still require reindexing to populate previously omitted search rows.

Closes #19.

## Verification

- `go test ./...`
- `go test -tags integration -timeout 300s ./internal/store -run '^TestSearch_ObservationDateChoice$' -count=1 -v`
- `go test -race -count=1 ./internal/fhirpath ./internal/store`
- `go vet ./...`
- `git diff --check`
