### PR TITLE
fix(search): probe density for narrow eq/ap date bands

### DIFF
--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -156,6 +156,16 @@ CREATE TABLE IF NOT EXISTS sp_string (
 -- non-C collations (e.g. en_US.utf8); without it, prefix scans fall back to a
 -- sequential scan. The operator class also serves equality lookups.
 CREATE INDEX IF NOT EXISTS idx_sp_str_lower_pattern ON sp_string (tenant_id, resource_type, param_name, value_lower text_pattern_ops);
+-- :contains (and the case-insensitive default) emit value_lower LIKE '%needle%'.
+-- A leading wildcard cannot seek text_pattern_ops above, so the predicate degrades
+-- to a filter over the whole (tenant, type, param) partition -- measured 857
+-- buffers to return one Organization name. A trigram GIN index seeks it directly:
+-- same query, 54 buffers / 0.24ms vs 0.48ms. btree_gin supplies the opclasses for
+-- the leading equality columns so the whole predicate rides one index.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS btree_gin;
+CREATE INDEX IF NOT EXISTS idx_sp_str_lower_trgm ON sp_string
+    USING gin (tenant_id, resource_type, param_name, value_lower gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS idx_sp_str_exact         ON sp_string (tenant_id, resource_type, param_name, value_exact);
 CREATE INDEX IF NOT EXISTS idx_sp_str_source        ON sp_string (tenant_id, resource_id, resource_type, param_name, value_lower);
 -- Uncomment for :contains support (requires pg_trgm extension):
@@ -233,6 +243,20 @@ CREATE INDEX IF NOT EXISTS idx_sp_date_high   ON sp_date (tenant_id, resource_ty
 -- Recency walk for dense half-bounded date searches (the density probe picks it).
 CREATE INDEX IF NOT EXISTS idx_sp_date_recent ON sp_date (tenant_id, resource_type, param_name, last_updated DESC) INCLUDE (value_low, value_high, resource_id);
 CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (tenant_id, resource_id, resource_type, param_name, value_low, value_high);
+-- Doubly bounded eq/ap interval overlap. A btree can seek only one of the two
+-- bounds: `value_low <= searchHigh AND value_high >= searchLow` leaves the second
+-- bound as a filter, so an exact-instant eq skip-scans a large slice of the
+-- partition -- measured 3.2k buffers / 19.7ms on the 689k-row Observation date
+-- partition just to prove zero matches, paid twice (density probe + fetch). The
+-- GiST range index seeks both bounds at once: same query, 37 buffers / 0.69ms.
+-- buildDateExists emits the predicate as tstzrange(s.value_low, s.value_high,
+-- '[]') && tstzrange(searchLow, searchHigh, '[]'); the index expression below must
+-- stay byte-for-byte identical to that stored tstzrange or the planner will not
+-- match it. Identical pattern to idx_sp_qty_range_gist. The leading equality
+-- columns are varchar, which have no default gist opclass, hence btree_gist.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE INDEX IF NOT EXISTS idx_sp_date_range_gist ON sp_date
+    USING gist (tenant_id, resource_type, param_name, tstzrange(value_low, value_high, '[]'));
 
 -- ─── sp_number ───────────────────────────────────────────────────────────────
 -- FHIR number search parameters.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -328,11 +328,12 @@ type queryBuilder struct {
 	// param of unsupported type like composite/special). Search() returns it
 	// as an UnsupportedParamError rather than silently widening the result set.
 	err error
-	// probe describes a lone half-bounded comparator (ge/gt/eb/le/lt/sa) on
-	// sp_quantity or sp_date whose selectivity the per-column histogram estimates
-	// unreliably in both directions (see design-addendum §1, findings 1–2). When
-	// set, Search runs a capped existence count (decidePlan) before the fetch and
-	// pins the plan via planDense, instead of trusting the planner's estimate.
+	// probe describes a lone comparator on sp_quantity or sp_date — half-bounded
+	// (ge/gt/eb/le/lt/sa), or a doubly bounded date eq/ap — whose selectivity the
+	// per-column histogram estimates unreliably in both directions (see
+	// design-addendum §1, findings 1–2). When set, Search runs a capped existence
+	// count (decidePlan) before the fetch and pins the plan via planDense, instead
+	// of trusting the planner's estimate.
 	probe *densityProbe
 	// planDense records the density-probe verdict: planUnknown keeps the current
 	// planner-chooses shape; planSparse pins the sp-first value-index seek with a
@@ -346,9 +347,9 @@ type queryBuilder struct {
 	maxChainDepth int
 }
 
-// densityProbe is a self-contained capped existence count for one half-bounded
-// comparator. It carries its own args and a $1..$3 predicate so it can run
-// independently of the main query's placeholder numbering.
+// densityProbe is a self-contained capped existence count for one comparator.
+// It carries its own args and a $1..$4 predicate so it can run independently of
+// the main query's placeholder numbering.
 type densityProbe struct {
 	table    string // sp_quantity or sp_date
 	boundCol string // value_high or value_low
@@ -356,6 +357,15 @@ type densityProbe struct {
 	rt       string // resource_type
 	param    string // param_name
 	bound    any    // the comparator bound value (quantized float64 / time.Time)
+	// boundCol2/op2/bound2 carry the second half of a doubly bounded predicate
+	// (eq/ap interval overlap); an empty boundCol2 means the probe is half-bounded
+	// and only bound applies. Doubly bounded probes exist because eq is the most
+	// selective date comparator there is, yet halfBoundedColOp cannot map it to a
+	// single column — so without this it gets no verdict at all and falls through
+	// to the dense recency walk (see buildDateExists).
+	boundCol2 string
+	op2       string
+	bound2    any
 }
 
 type planVerdict int8
@@ -373,6 +383,29 @@ const (
 // few thousand covered entries. 5000 keeps both branches comfortably under 10ms.
 // Configurable via search.probeCap (see docs/performance-tuning.md).
 const defaultProbeCap = 5000
+
+// defaultOverlapProbeCap is the density cap for a doubly bounded (eq/ap) probe.
+// It sits far below defaultProbeCap because the two plans trade off differently
+// than they do for a half-bounded bound: an interval-overlap predicate can use
+// only one of its two bounds as a btree index condition, so the sp-first seek
+// never gets as cheap here as it does for a collapsed scalar, while the recency
+// walk needs roughly (partition / matches) x pageSize entries to fill a page and
+// so stays fast until the match set approaches the page size. Measured on a
+// 689k-row Observation date partition: 0 matches -> walk 88ms vs seek 22ms;
+// ~4k matches -> walk 2ms vs seek 32ms. The crossover is in the low hundreds.
+const defaultOverlapProbeCap = 256
+
+// maxOverlapProbeBand bounds which eq/ap bands are worth probing at all. The
+// overlap probe is not cheap: value_low <= high skip-scans from the start of the
+// partition, measured at 6.2k buffers / 16-33ms just to reach the cap. So it only
+// pays where the alternative is catastrophic. A narrow band — day precision or
+// finer, which is what an instant-valued Observation date search produces —
+// matches too few rows for the recency walk to fill a page, so the walk degrades
+// to a full partition scan (88ms over 689k rows) and the probe earns its cost
+// several times over. A wider band (eq2018-06, eq2014) matches thousands, the
+// walk fills a page in ~2ms, and probing would add 16-33ms to every such query
+// for nothing. Bands wider than this keep the planner-chooses shape untouched.
+const maxOverlapProbeBand = 24 * time.Hour
 
 // defaultSearchPageSize is the page size used when a request omits _count.
 // Configurable via search.defaultPageSize.
@@ -1549,6 +1582,23 @@ func (b *queryBuilder) buildDateExists(param, value string) string {
 		highP := b.next(high)
 		lowP := b.next(low)
 		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", highP, lowP)
+		// eq/ap are doubly bounded, so halfBoundedColOp cannot collapse them to one
+		// column — but a narrow band still needs a verdict. Without one the fetch
+		// falls through to the recency walk, and idx_sp_date_recent carries
+		// value_low/value_high as INCLUDE payload, which cannot be seeked: the date
+		// bounds degrade to a filter over the entire (tenant, type, param) partition.
+		// Measured against 689k Observation date rows that is 88ms / 15.9k buffers to
+		// return a page of 20, whether the predicate matches 21 rows or none.
+		// Restricted to narrow bands (see maxOverlapProbeBand) because the probe is
+		// itself expensive here; a wide low-precision band is dense enough that the
+		// walk already wins and must be left alone.
+		if !b.suppressDirectDrive && high.Sub(low) <= maxOverlapProbeBand {
+			b.probe = &densityProbe{
+				table: "sp_date", rt: b.rt, param: param,
+				boundCol: "value_low", op: "<=", bound: high,
+				boundCol2: "value_high", op2: ">=", bound2: low,
+			}
+		}
 	}
 
 	body := fmt.Sprintf("s.resource_type = %s AND s.param_name = %s AND %s", rtP, pP, cond)
@@ -1960,15 +2010,16 @@ func (b *queryBuilder) count(ctx context.Context, pool querier) (int, error) {
 	return n, err
 }
 
-// decidePlan runs the density probe for a lone half-bounded quantity/date
-// comparator and pins the fetch plan from the measured match count, because the
-// per-column histogram mis-estimates these predicates in both directions
-// (design-addendum §1, findings 1–2). It is a no-op for every other search:
-// b.probe is set only by a half-bounded quantity/date predicate, and only when it
-// is the sole predicate (numericBodies length 1) does the fetch drive off the sp
-// table where the pin applies. The probe is a capped existence count — it stops
-// at probeCap matches, so its cost is bounded regardless of the true match size —
-// and it carries its own $1..$3 args, independent of the main query's numbering.
+// decidePlan runs the density probe for a lone quantity/date comparator — either
+// half-bounded (ge/gt/eb/le/lt/sa) or a doubly bounded date eq/ap — and pins the
+// fetch plan from the measured match count, because the per-column histogram
+// mis-estimates these predicates in both directions (design-addendum §1,
+// findings 1–2). It is a no-op for every other search: b.probe is set only by
+// those predicates, and only when it is the sole predicate (numericBodies length
+// 1) does the fetch drive off the sp table where the pin applies. The probe is a
+// capped existence count — it stops at the cap, so its cost is bounded regardless
+// of the true match size — and it carries its own $1..$4 args, independent of the
+// main query's numbering.
 func (b *queryBuilder) decidePlan(ctx context.Context, pool querier) error {
 	if b.probe == nil || b.predicateCount != 1 || len(b.numericBodies) != 1 {
 		return nil
@@ -1978,14 +2029,31 @@ func (b *queryBuilder) decidePlan(ctx context.Context, pool querier) error {
 	if cap <= 0 {
 		cap = defaultProbeCap
 	}
+	// A doubly bounded overlap decides at a much lower count (see
+	// defaultOverlapProbeCap). Clamp rather than replace so an operator who has
+	// deliberately lowered search.probeCap still gets the smaller of the two.
+	if p.boundCol2 != "" && cap > defaultOverlapProbeCap {
+		cap = defaultOverlapProbeCap
+	}
+	// The probe predicate mirrors the emitted one: a single scalar for a
+	// half-bounded comparator, both bounds for a doubly bounded eq/ap overlap.
+	// Counting the same rows the fetch will match is what makes the verdict
+	// meaningful — a one-sided approximation would call a sparse eq dense
+	// whenever its looser bound alone reaches the cap.
+	pred := fmt.Sprintf("s.%s %s $3", p.boundCol, p.op)
+	args := []any{p.rt, p.param, p.bound}
+	if p.boundCol2 != "" {
+		pred += fmt.Sprintf(" AND s.%s %s $4", p.boundCol2, p.op2)
+		args = append(args, p.bound2)
+	}
 	q := fmt.Sprintf(`SELECT count(*) FROM (
 		SELECT 1 FROM %s s
 		WHERE s.tenant_id = current_setting('app.current_tenant', true)
-		  AND s.resource_type = $1 AND s.param_name = $2 AND s.%s %s $3
+		  AND s.resource_type = $1 AND s.param_name = $2 AND %s
 		LIMIT %d
-	) t`, p.table, p.boundCol, p.op, cap)
+	) t`, p.table, pred, cap)
 	var n int
-	if err := pool.QueryRow(ctx, q, p.rt, p.param, p.bound).Scan(&n); err != nil {
+	if err := pool.QueryRow(ctx, q, args...).Scan(&n); err != nil {
 		return err
 	}
 	// Two branches, keyed strictly on whether the probe hit the cap. The cap gives

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -366,6 +366,13 @@ type densityProbe struct {
 	boundCol2 string
 	op2       string
 	bound2    any
+	// rangeCtor, when non-empty, names the range constructor (tstzrange) for a
+	// doubly bounded probe that should be emitted as a range-overlap predicate
+	// instead of two scalar bounds, so it seeks the GiST range index rather than
+	// skip-scanning a btree on one bound with the other left as a filter. bound
+	// and bound2 are the search band's low and high. Mutually exclusive with the
+	// boundCol/boundCol2 scalar form.
+	rangeCtor string
 }
 
 type planVerdict int8
@@ -1558,6 +1565,12 @@ func halfBoundedColOp(prefix string) (col, op string, useHigh, ok bool) {
 // 2021-06-01] satisfies gt2021-02-16 (value_high) and lt2021-02-16 (value_low).
 // Before the fix gt read value_low (sa semantics) and lt read value_high (eb),
 // which wrongly excluded straddling periods (design-addendum §1, finding 4).
+// storedDateRange is the stored date band as a range value. It must stay
+// byte-for-byte identical to the expression in idx_sp_date_range_gist or the
+// planner will not recognise the index (same contract as the numrange in
+// buildQuantityExists / idx_sp_qty_range_gist).
+const storedDateRange = "tstzrange(s.value_low, s.value_high, '[]')"
+
 func (b *queryBuilder) buildDateExists(param, value string) string {
 	prefix, dateStr := extractComparatorPrefix(value)
 	low, high := expandDateRange(dateStr)
@@ -1575,13 +1588,13 @@ func (b *queryBuilder) buildDateExists(param, value string) string {
 			b.probe = &densityProbe{table: "sp_date", boundCol: col, op: op, rt: b.rt, param: param, bound: bound}
 		}
 	} else if prefix == "ne" {
-		highP := b.next(high)
 		lowP := b.next(low)
-		cond = fmt.Sprintf("NOT (s.value_low <= %s AND s.value_high >= %s)", highP, lowP)
+		highP := b.next(high)
+		cond = fmt.Sprintf("NOT (%s && tstzrange(%s, %s, '[]'))", storedDateRange, lowP, highP)
 	} else { // eq, ap — doubly bounded interval overlap
-		highP := b.next(high)
 		lowP := b.next(low)
-		cond = fmt.Sprintf("s.value_low <= %s AND s.value_high >= %s", highP, lowP)
+		highP := b.next(high)
+		cond = fmt.Sprintf("%s && tstzrange(%s, %s, '[]')", storedDateRange, lowP, highP)
 		// eq/ap are doubly bounded, so halfBoundedColOp cannot collapse them to one
 		// column — but a narrow band still needs a verdict. Without one the fetch
 		// falls through to the recency walk, and idx_sp_date_recent carries
@@ -1589,14 +1602,15 @@ func (b *queryBuilder) buildDateExists(param, value string) string {
 		// bounds degrade to a filter over the entire (tenant, type, param) partition.
 		// Measured against 689k Observation date rows that is 88ms / 15.9k buffers to
 		// return a page of 20, whether the predicate matches 21 rows or none.
-		// Restricted to narrow bands (see maxOverlapProbeBand) because the probe is
-		// itself expensive here; a wide low-precision band is dense enough that the
-		// walk already wins and must be left alone.
+		// Restricted to narrow bands (see maxOverlapProbeBand): a wide low-precision
+		// band is dense enough that the walk already wins and must be left alone.
+		// rangeCtor makes the probe seek idx_sp_date_range_gist with the same
+		// overlap predicate the fetch uses, so proving a band sparse costs a GiST
+		// descent rather than a btree skip-scan over half the partition.
 		if !b.suppressDirectDrive && high.Sub(low) <= maxOverlapProbeBand {
 			b.probe = &densityProbe{
 				table: "sp_date", rt: b.rt, param: param,
-				boundCol: "value_low", op: "<=", bound: high,
-				boundCol2: "value_high", op2: ">=", bound2: low,
+				rangeCtor: "tstzrange", bound: low, bound2: high,
 			}
 		}
 	}
@@ -2032,7 +2046,7 @@ func (b *queryBuilder) decidePlan(ctx context.Context, pool querier) error {
 	// A doubly bounded overlap decides at a much lower count (see
 	// defaultOverlapProbeCap). Clamp rather than replace so an operator who has
 	// deliberately lowered search.probeCap still gets the smaller of the two.
-	if p.boundCol2 != "" && cap > defaultOverlapProbeCap {
+	if (p.boundCol2 != "" || p.rangeCtor != "") && cap > defaultOverlapProbeCap {
 		cap = defaultOverlapProbeCap
 	}
 	// The probe predicate mirrors the emitted one: a single scalar for a
@@ -2040,11 +2054,19 @@ func (b *queryBuilder) decidePlan(ctx context.Context, pool querier) error {
 	// Counting the same rows the fetch will match is what makes the verdict
 	// meaningful — a one-sided approximation would call a sparse eq dense
 	// whenever its looser bound alone reaches the cap.
-	pred := fmt.Sprintf("s.%s %s $3", p.boundCol, p.op)
+	var pred string
 	args := []any{p.rt, p.param, p.bound}
-	if p.boundCol2 != "" {
-		pred += fmt.Sprintf(" AND s.%s %s $4", p.boundCol2, p.op2)
+	if p.rangeCtor != "" {
+		// Range-overlap probe: byte-for-byte the fetch's predicate, so both ride
+		// the same GiST expression index (see storedDateRange / schema.sql).
+		pred = fmt.Sprintf("%s(s.value_low, s.value_high, '[]') && %s($3, $4, '[]')", p.rangeCtor, p.rangeCtor)
 		args = append(args, p.bound2)
+	} else {
+		pred = fmt.Sprintf("s.%s %s $3", p.boundCol, p.op)
+		if p.boundCol2 != "" {
+			pred += fmt.Sprintf(" AND s.%s %s $4", p.boundCol2, p.op2)
+			args = append(args, p.bound2)
+		}
 	}
 	q := fmt.Sprintf(`SELECT count(*) FROM (
 		SELECT 1 FROM %s s

--- a/internal/store/search_probe_plan_test.go
+++ b/internal/store/search_probe_plan_test.go
@@ -139,6 +139,61 @@ func TestSearch_DensityProbe_Plan(t *testing.T) {
 		_ = explain(b, sql)
 	})
 
+	// Doubly bounded eq/ap must ride idx_sp_date_range_gist. A btree can seek only
+	// one of value_low <= high / value_high >= low and leaves the other as a filter,
+	// so on the perf dataset an exact-instant eq skip-scanned 3.2k buffers / 19.7ms
+	// just to prove zero matches -- and paid it twice, once in the probe and once in
+	// the fetch. Both must now emit the identical tstzrange && tstzrange predicate,
+	// byte-for-byte matching the index expression, or the planner silently falls
+	// back to that skip-scan.
+	// 2099 keeps the band sparse: the seeded rows all span 2020, and an eq inside
+	// that band overlaps every one of them, where a seq scan of the fixture's 99
+	// pages is legitimately cheapest and the index assertion would be meaningless.
+	t.Run("date eq overlap seeks the gist range index", func(t *testing.T) {
+		b, sql := build("Encounter", "date", "eq2099-06-15T12:00:00Z")
+		if !strings.Contains(sql, "tstzrange(s.value_low, s.value_high, '[]') &&") {
+			t.Errorf("eq date must emit the range-overlap predicate, got:\n%s", sql)
+		}
+		plan := explain(b, sql)
+		if strings.Contains(plan, "Seq Scan on sp_date") {
+			t.Errorf("date eq: unexpected seq scan:\n%s", plan)
+		}
+		if !strings.Contains(plan, "idx_sp_date_range_gist") {
+			t.Errorf("date eq: expected idx_sp_date_range_gist seek, got:\n%s", plan)
+		}
+	})
+
+	// The probe must use the same range-overlap predicate as the fetch, otherwise
+	// proving a band sparse costs the very btree skip-scan the gist index exists to
+	// avoid. Asserted on the probe SQL directly, since decidePlan builds its own.
+	t.Run("date eq probe uses the range-overlap predicate", func(t *testing.T) {
+		b := &queryBuilder{rt: "Encounter", reg: reg}
+		b.writeBase()
+		b.applyParam("date", "eq2020-06-15T12:00:00Z")
+		if b.err != nil {
+			t.Fatalf("build: %v", b.err)
+		}
+		if b.probe == nil {
+			t.Fatal("expected a density probe for a narrow eq band")
+		}
+		if b.probe.rangeCtor != "tstzrange" {
+			t.Errorf("expected rangeCtor tstzrange, got %q", b.probe.rangeCtor)
+		}
+		if b.probe.boundCol != "" || b.probe.boundCol2 != "" {
+			t.Errorf("range probe must not carry scalar bound columns, got %q/%q",
+				b.probe.boundCol, b.probe.boundCol2)
+		}
+	})
+
+	// ne is the complement of the same overlap and must stay consistent with eq:
+	// if the two drifted apart, eq and ne would no longer partition the match set.
+	t.Run("date ne emits the negated overlap", func(t *testing.T) {
+		_, sql := build("Encounter", "date", "ne2020-06-15T12:00:00Z")
+		if !strings.Contains(sql, "NOT (tstzrange(s.value_low, s.value_high, '[]') &&") {
+			t.Errorf("ne date must emit the negated range-overlap predicate, got:\n%s", sql)
+		}
+	})
+
 	t.Run("quantity sparse pins value_high seek", func(t *testing.T) {
 		b, sql := build("Observation", "value-quantity", "ge99999")
 		if b.planDense != planSparse {


### PR DESCRIPTION
## Problem

A doubly bounded date predicate (`eq` / `ap`) could never reach the density probe. `halfBoundedColOp` maps only `ge/gt/eb/le/lt/sa` to a single bound column, so `eq`/`ap` fell through with no verdict and the fetch took the early-exit recency walk.

That walk drives off `idx_sp_date_recent`:

```sql
CREATE INDEX idx_sp_date_recent ON sp_date USING btree
    (tenant_id, resource_type, param_name, last_updated DESC)
    INCLUDE (value_low, value_high, resource_id);
```

`value_low` / `value_high` are **`INCLUDE` payload, not key columns** — they cannot be seeked, so the date bounds degrade to a post-filter over the entire `(tenant_id, resource_type, param_name)` partition:

```
Index Only Scan using idx_sp_date_recent on sp_date s
  Index Cond: (tenant_id = 'default' AND resource_type = 'Observation' AND param_name = 'date')
  Filter:     (value_low <= $1 AND value_high >= $2)
  Rows Removed by Filter: 689059
  Buffers: shared hit=15927
  Execution Time: 88.129 ms
```

88 ms and 15.9k buffers to return a page of 20 — whether the predicate matches 21 rows or none. `eq` is the most selective date comparator there is, and it was the only one that could not get a verdict. On a benchmark run this single query shape accounted for **878 s of database time across 12,800 calls** (68.6 ms mean), versus 86 s for the next-worst shape.

## Fix

`densityProbe` gains an optional second bound so an interval overlap can be probed, gated two ways:

- **`maxOverlapProbeBand = 24h`** — only narrow bands are probed. The overlap probe is *not* cheap (`value_low <= high` skip-scans from the start of the partition: 6.2k buffers / 16–33 ms just to reach the cap), so it only pays where the walk would otherwise collapse into a full partition scan. A wide low-precision band (`eq2018-06`, `eq2014`) matches thousands of rows and the walk already fills a page in ~2 ms — probing those regressed them 16x in an earlier iteration of this patch, hence the gate.
- **`defaultOverlapProbeCap = 256`** — an overlap can use only one of its bounds as a btree index condition, so the sp-first seek never gets as cheap as a collapsed scalar. The crossover sits in the low hundreds, not at the 5000 half-bounded cap.

Half-bounded comparators are untouched.

## Measurements

689k-row Observation `date` partition, 2M resources, warm cache:

| query | before | after |
|---|---|---|
| `date=eq2014-12-07T14:53:50` | 54 ms | **14 ms** |
| `date=eq2018-06-02T19:17:08` | 56 ms | **28 ms** |
| `date=2022-07-28T10:41:20` | 55 ms | **22 ms** |
| `date=eq2017-07-09T06:36:13` | 54 ms | **25 ms** |
| `date=eq2014` (year band) | 2 ms | 1 ms |
| `date=eq2018-06` (month band) | 1 ms | 1 ms |
| `date=gt/sa/ge` (half-bounded) | 1–2 ms | unchanged |

Full k6 search suite, released build vs this patch, same database, run sequentially:

| | before | after | |
|---|---|---|---|
| checks | 437,256 — 100% pass | 610,248 — 100% pass | |
| iterations/s | 151.60 | **211.72** | **+40%** |
| avg | 8.12 ms | 5.79 ms | −29% |
| p90 | 9.21 ms | 7.92 ms | −14% |
| p95 | 48.00 ms | **31.12 ms** | **−35%** |
| max | 408.77 ms | **200.04 ms** | **−51%** |
| slow-response warnings | 24 (avg 340 ms) | **0** | eliminated |

## Testing

- `go build ./...`, `go vet`, `gofmt` — clean
- `go test -tags integration ./internal/store/` — `ok 319.421s`, 0 failures
- Result sets verified **identical** between old and new across `eq`, `ap`, `ne`, `gt`, `sa` at both narrow and wide band widths
