### PR TITLE
perf(store): diff-based re-index and pipelined flush for the update path

### DIFF
--- a/internal/index/rowset.go
+++ b/internal/index/rowset.go
@@ -69,6 +69,15 @@ var spDeleteTables = []string{
 	"sp_quantity", "sp_uri", "sp_reference", "sp_composite_token_quantity",
 }
 
+// noRecencyTables are the sp_* tables without a denormalised last_updated
+// column. Their rows are a pure function of the resource body, so a re-index
+// that would write value-identical rows can skip the table entirely. Every
+// other table's rows embed last_updated (served back by the covering recency
+// scans in store/search.go in place of resources.last_updated), so those rows
+// must be rewritten on every update to stay fresh even when the indexed values
+// did not change.
+var noRecencyTables = map[string]bool{"sp_string": true, "sp_uri": true}
+
 // refKey identifies a resource whose existing sp_* rows must be cleared before
 // its freshly extracted rows are inserted (the re-index on update/patch/delete).
 type refKey struct {
@@ -77,10 +86,10 @@ type refKey struct {
 }
 
 // RowSet accumulates the sp_* index rows for one database transaction so the
-// whole transaction's index writes flush as a handful of COPY (and, for
-// re-indexed resources, one batched DELETE per table) statements instead of one
-// INSERT/DELETE per row. A single bundle transaction shares one RowSet across
-// all its entries; the single-resource CRUD paths use one with a batch of one.
+// whole transaction's index writes flush as a handful of batched DELETE and
+// multi-row INSERT statements instead of one INSERT/DELETE per row. A single
+// bundle transaction shares one RowSet across all its entries; the
+// single-resource CRUD paths use one with a batch of one.
 //
 // The row slices hold values in the column order declared above, tenant_id
 // first. Callers append via the extractor's append* helpers.
@@ -105,17 +114,49 @@ type RowSet struct {
 	spReference [][]any
 	spComposite [][]any
 
-	// deletes is the ordered, de-duplicated set of resources to clear before
-	// insert; deleteSeen guards the dedup.
-	deletes    []refKey
-	deleteSeen map[refKey]struct{}
+	// deletes is the ordered, de-duplicated set of (table, resource) re-index
+	// DELETEs to run before insert; deleteSeen guards the dedup. Registration is
+	// per table so an update that provably left a table untouched (see
+	// MergeReindex) issues no DELETE against it at all.
+	deletes    map[string][]refKey
+	deleteSeen map[string]map[refKey]struct{}
 }
 
 // NewRowSet returns an empty RowSet stamped with the transaction's tenant (written
 // into every row's tenant_id column) and bounded to maxRows total sp_* rows
 // (0 = unlimited).
 func NewRowSet(tenant string, maxRows int) *RowSet {
-	return &RowSet{tenant: tenant, maxRows: maxRows, deleteSeen: map[refKey]struct{}{}}
+	return &RowSet{
+		tenant:     tenant,
+		maxRows:    maxRows,
+		deletes:    map[string][]refKey{},
+		deleteSeen: map[string]map[refKey]struct{}{},
+	}
+}
+
+// spSlice maps a table name to the RowSet slice holding its buffered rows, in
+// spDeleteTables order. Kept as a method (not a stored field) so the returned
+// pointers always address the current slices.
+func (rs *RowSet) spSlice(table string) *[][]any {
+	switch table {
+	case "sp_string":
+		return &rs.spString
+	case "sp_token":
+		return &rs.spToken
+	case "sp_date":
+		return &rs.spDate
+	case "sp_number":
+		return &rs.spNumber
+	case "sp_quantity":
+		return &rs.spQuantity
+	case "sp_uri":
+		return &rs.spURI
+	case "sp_reference":
+		return &rs.spReference
+	case "sp_composite_token_quantity":
+		return &rs.spComposite
+	}
+	return nil
 }
 
 // Count returns the total number of sp_* rows currently buffered across all tables.
@@ -148,55 +189,167 @@ func (rs *RowSet) TableCounts() map[string]int {
 }
 
 // AddDelete records that resource (resourceType, resourceID) must have its
-// existing sp_* rows removed at flush (re-index), and drops any rows already
-// accumulated for it earlier in this transaction. The purge keeps a
-// create-then-update of the same resource within one bundle byte-identical to
-// the old per-op delete-then-reinsert: only the final version's rows survive.
+// existing sp_* rows removed from every table at flush (full re-index), and
+// drops any rows already accumulated for it earlier in this transaction. The
+// purge keeps a create-then-update of the same resource within one bundle
+// byte-identical to the old per-op delete-then-reinsert: only the final
+// version's rows survive.
 func (rs *RowSet) AddDelete(resourceType, resourceID string) {
 	k := refKey{resourceID: resourceID, resourceType: resourceType}
-	if _, ok := rs.deleteSeen[k]; !ok {
-		rs.deleteSeen[k] = struct{}{}
-		rs.deletes = append(rs.deletes, k)
+	for _, tbl := range spDeleteTables {
+		rs.addTableDelete(tbl, k)
 	}
-	rs.purge(k)
 }
 
-// purge removes any accumulated rows for k from every sp_* slice. Row layout is
-// [tenant_id, resource_id, resource_type, ...], so indexes 1 and 2 identify the
-// owning resource.
-func (rs *RowSet) purge(k refKey) {
-	filter := func(rows [][]any) [][]any {
-		out := rows[:0]
-		for _, r := range rows {
-			if r[1] == k.resourceID && r[2] == k.resourceType {
-				continue
-			}
-			out = append(out, r)
+// addTableDelete registers the re-index DELETE for one (table, resource) pair
+// and purges that table's buffered rows for the resource, so only the final
+// version's rows survive when one transaction touches a resource repeatedly.
+func (rs *RowSet) addTableDelete(table string, k refKey) {
+	seen := rs.deleteSeen[table]
+	if seen == nil {
+		seen = map[refKey]struct{}{}
+		rs.deleteSeen[table] = seen
+	}
+	if _, ok := seen[k]; !ok {
+		seen[k] = struct{}{}
+		rs.deletes[table] = append(rs.deletes[table], k)
+	}
+	rs.purgeTable(table, k)
+}
+
+// purgeTable removes any accumulated rows for k from one sp_* slice. Row layout
+// is [tenant_id, resource_id, resource_type, ...], so indexes 1 and 2 identify
+// the owning resource.
+func (rs *RowSet) purgeTable(table string, k refKey) {
+	sl := rs.spSlice(table)
+	out := (*sl)[:0]
+	for _, r := range *sl {
+		if r[1] == k.resourceID && r[2] == k.resourceType {
+			continue
 		}
-		return out
+		out = append(out, r)
 	}
-	rs.spString = filter(rs.spString)
-	rs.spToken = filter(rs.spToken)
-	rs.spDate = filter(rs.spDate)
-	rs.spNumber = filter(rs.spNumber)
-	rs.spQuantity = filter(rs.spQuantity)
-	rs.spURI = filter(rs.spURI)
-	rs.spReference = filter(rs.spReference)
-	rs.spComposite = filter(rs.spComposite)
+	*sl = out
 }
 
-// Flush writes the accumulated index changes to tx: first the batched re-index
-// DELETEs (one statement per sp_* table over every collected resource key), then
-// chunked multi-row INSERTs per sp_* table. DELETEs precede INSERTs so a
-// re-indexed resource's stale rows are gone before its fresh rows land. The
-// caller runs this inside the bundle's transaction, after all entries are
-// processed and after the parent resources rows exist (the sp_* FK), and before
-// COMMIT.
-func (rs *RowSet) Flush(ctx context.Context, tx pgx.Tx, maxRowsPerStmt int) error {
-	if len(rs.deletes) > 0 {
-		ids := make([]string, len(rs.deletes))
-		types := make([]string, len(rs.deletes))
-		for i, k := range rs.deletes {
+// MergeReindex merges the re-index of one resource into rs, given the rows
+// extracted from the stored version (oldRS; empty when the resource was absent
+// or soft-deleted) and from the incoming version (newRS; empty for a delete).
+// Per table it decides between three outcomes:
+//
+//   - both versions have no rows → nothing at all (the former unconditional
+//     8-table DELETE storm ran mostly against tables like this);
+//   - the table carries no denormalised last_updated (noRecencyTables) and the
+//     extracted rows are value-identical → leave the stored rows untouched;
+//   - otherwise → register the table-scoped DELETE and buffer the new rows.
+//
+// Both temporary RowSets must share rs's tenant. The buffered-row cap and
+// LimitHit stay in force: appends stop at rs.maxRows, and a LimitHit on either
+// temporary set propagates so the writer still aborts oversized transactions.
+func (rs *RowSet) MergeReindex(oldRS, newRS *RowSet, resourceType, resourceID string) {
+	k := refKey{resourceID: resourceID, resourceType: resourceType}
+	for _, tbl := range spDeleteTables {
+		oldRows := *oldRS.spSlice(tbl)
+		newRows := *newRS.spSlice(tbl)
+		if len(oldRows) == 0 && len(newRows) == 0 {
+			continue
+		}
+		if noRecencyTables[tbl] && rowsEqual(oldRows, newRows) {
+			continue
+		}
+		rs.addTableDelete(tbl, k)
+		dst := rs.spSlice(tbl)
+		for _, r := range newRows {
+			if rs.atLimit() {
+				rs.LimitHit = true
+				break
+			}
+			*dst = append(*dst, r)
+		}
+	}
+	if oldRS.LimitHit || newRS.LimitHit {
+		rs.LimitHit = true
+	}
+}
+
+// rowsEqual reports whether two buffered row slices are identical position by
+// position. Extraction is deterministic for a given body and registry, so an
+// unchanged resource subtree yields the same rows in the same order; any
+// mismatch (including reordering) just falls back to a full re-index of the
+// table. Only called for noRecencyTables, whose values are strings/nil and
+// therefore directly comparable.
+func rowsEqual(a, b [][]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if len(a[i]) != len(b[i]) {
+			return false
+		}
+		for j := range a[i] {
+			if a[i][j] != b[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Batch collects statements for one pipelined round trip, wrapping pgx.Batch
+// with a parallel label per statement so a failure still names the table it
+// targeted, exactly as the former one-Exec-per-statement writes did.
+type Batch struct {
+	b      pgx.Batch
+	labels []string
+}
+
+// Queue adds one statement to the batch under a diagnostic label.
+func (qb *Batch) Queue(label, sql string, args ...any) {
+	qb.b.Queue(sql, args...)
+	qb.labels = append(qb.labels, label)
+}
+
+// Len returns the number of queued statements.
+func (qb *Batch) Len() int { return qb.b.Len() }
+
+// Send runs every queued statement in one pipelined round trip on tx and
+// surfaces the first failure with its statement's label. A no-op when empty.
+// Statements execute in queue order, so callers preserve FK ordering (parent
+// resources rows before sp_* rows) simply by queueing in that order.
+func (qb *Batch) Send(ctx context.Context, tx pgx.Tx) error {
+	if qb.b.Len() == 0 {
+		return nil
+	}
+	br := tx.SendBatch(ctx, &qb.b)
+	var execErr error
+	for i := 0; i < qb.b.Len(); i++ {
+		if _, err := br.Exec(); err != nil {
+			execErr = fmt.Errorf("%s: %w", qb.labels[i], err)
+			break
+		}
+	}
+	if cerr := br.Close(); execErr == nil && cerr != nil {
+		execErr = cerr
+	}
+	return execErr
+}
+
+// QueueFlush queues the accumulated index changes: first the batched re-index
+// DELETEs (one statement per touched sp_* table over that table's collected
+// resource keys), then chunked multi-row INSERTs per sp_* table. DELETEs
+// precede INSERTs so a re-indexed resource's stale rows are gone before its
+// fresh rows land. The caller sends the batch inside the transaction, after
+// all entries are processed and after the parent resources rows are queued
+// (the sp_* FK), and before COMMIT.
+func (rs *RowSet) QueueFlush(qb *Batch, maxRowsPerStmt int) {
+	for _, tbl := range spDeleteTables {
+		keys := rs.deletes[tbl]
+		if len(keys) == 0 {
+			continue
+		}
+		ids := make([]string, len(keys))
+		types := make([]string, len(keys))
+		for i, k := range keys {
 			ids[i] = k.resourceID
 			types[i] = k.resourceType
 		}
@@ -204,15 +357,11 @@ func (rs *RowSet) Flush(ctx context.Context, tx pgx.Tx, maxRowsPerStmt int) erro
 		// replacing the former per-resource DELETE storm. UNNEST pairs the two
 		// parallel arrays positionally. The tenant predicate mirrors the original
 		// per-row DELETE so exactly the same rows are removed.
-		for _, tbl := range spDeleteTables {
-			q := fmt.Sprintf(`DELETE FROM %s t
-			                  USING (SELECT UNNEST($1::text[]) AS rid, UNNEST($2::text[]) AS rt) d
-			                  WHERE t.tenant_id = current_setting('app.current_tenant', true)
-			                    AND t.resource_id = d.rid AND t.resource_type = d.rt`, tbl)
-			if _, err := tx.Exec(ctx, q, ids, types); err != nil {
-				return fmt.Errorf("batch re-index delete from %s: %w", tbl, err)
-			}
-		}
+		q := fmt.Sprintf(`DELETE FROM %s t
+		                  USING (SELECT UNNEST($1::text[]) AS rid, UNNEST($2::text[]) AS rt) d
+		                  WHERE t.tenant_id = current_setting('app.current_tenant', true)
+		                    AND t.resource_id = d.rid AND t.resource_type = d.rt`, tbl)
+		qb.Queue("batch re-index delete from "+tbl, q, ids, types)
 	}
 
 	tables := []struct {
@@ -230,23 +379,29 @@ func (rs *RowSet) Flush(ctx context.Context, tx pgx.Tx, maxRowsPerStmt int) erro
 		{"sp_composite_token_quantity", spCompositeCols, rs.spComposite},
 	}
 	for _, t := range tables {
-		if err := InsertBatched(ctx, tx, t.name, t.cols, t.rows, maxRowsPerStmt); err != nil {
-			return err
-		}
+		QueueInsertBatched(qb, t.name, t.cols, t.rows, maxRowsPerStmt)
 	}
-	return nil
 }
 
-// InsertBatched inserts rows into table with multi-row INSERT ... VALUES
-// statements. Each statement carries at most maxRowsPerStmt rows, additionally
-// clamped so no statement exceeds maxInsertParams bind parameters (the wire
-// protocol's hard limit). It is a no-op for an empty slice. Exported so the store
-// reuses it for the resources and resource_history batched writes, keeping one
-// write mechanism. Every value is passed as a bind parameter, so the RLS
-// WITH CHECK policy validates each row exactly as the former per-row INSERTs did.
-func InsertBatched(ctx context.Context, tx pgx.Tx, table string, cols []string, rows [][]any, maxRowsPerStmt int) error {
+// Flush queues the accumulated index changes (see QueueFlush) and sends them in
+// one pipelined round trip on tx. Retained for callers that flush a RowSet on
+// its own, like the standalone Extractor.Index.
+func (rs *RowSet) Flush(ctx context.Context, tx pgx.Tx, maxRowsPerStmt int) error {
+	qb := &Batch{}
+	rs.QueueFlush(qb, maxRowsPerStmt)
+	return qb.Send(ctx, tx)
+}
+
+// QueueInsertBatched queues multi-row INSERT ... VALUES statements for rows.
+// Each statement carries at most maxRowsPerStmt rows, additionally clamped so
+// no statement exceeds maxInsertParams bind parameters (the wire protocol's
+// hard limit). It is a no-op for an empty slice. Exported so the store reuses
+// it for the resources and resource_history batched writes, keeping one write
+// mechanism. Every value is passed as a bind parameter, so the RLS WITH CHECK
+// policy validates each row exactly as the former per-row INSERTs did.
+func QueueInsertBatched(qb *Batch, table string, cols []string, rows [][]any, maxRowsPerStmt int) {
 	if len(rows) == 0 {
-		return nil
+		return
 	}
 	ncol := len(cols)
 	rowsPerChunk := maxRowsPerStmt
@@ -289,9 +444,14 @@ func InsertBatched(ctx context.Context, tx pgx.Tx, table string, cols []string, 
 			sb.WriteByte(')')
 			args = append(args, r...)
 		}
-		if _, err := tx.Exec(ctx, sb.String(), args...); err != nil {
-			return fmt.Errorf("batch insert into %s: %w", table, err)
-		}
+		qb.Queue("batch insert into "+table, sb.String(), args...)
 	}
-	return nil
+}
+
+// InsertBatched queues rows (see QueueInsertBatched) and sends them immediately
+// in one pipelined round trip on tx.
+func InsertBatched(ctx context.Context, tx pgx.Tx, table string, cols []string, rows [][]any, maxRowsPerStmt int) error {
+	qb := &Batch{}
+	QueueInsertBatched(qb, table, cols, rows, maxRowsPerStmt)
+	return qb.Send(ctx, tx)
 }

--- a/internal/store/bundle_copyfrom_stmtcount_integration_test.go
+++ b/internal/store/bundle_copyfrom_stmtcount_integration_test.go
@@ -51,6 +51,22 @@ func (t *stmtTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.
 
 func (t *stmtTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
 
+// Batch statements travel through the batch tracer hooks, not TraceQueryStart,
+// so the pipelined flush's statements are recorded here.
+func (t *stmtTracer) TraceBatchStart(ctx context.Context, _ *pgx.Conn, _ pgx.TraceBatchStartData) context.Context {
+	return ctx
+}
+
+func (t *stmtTracer) TraceBatchQuery(_ context.Context, _ *pgx.Conn, data pgx.TraceBatchQueryData) {
+	t.mu.Lock()
+	if t.enabled {
+		t.sqls = append(t.sqls, data.SQL)
+	}
+	t.mu.Unlock()
+}
+
+func (t *stmtTracer) TraceBatchEnd(context.Context, *pgx.Conn, pgx.TraceBatchEndData) {}
+
 func (t *stmtTracer) start() {
 	t.mu.Lock()
 	t.enabled = true

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -275,13 +275,15 @@ func (w *bundleWriter) flush(ctx context.Context, tx pgx.Tx) error {
 		)
 		return WriteLimitError{Rows: w.totalRows(), Limit: w.maxRowsPerBundle}
 	}
-	if err := index.InsertBatched(ctx, tx, "resources", resourcesCols, w.resources, w.maxRowsPerStmt); err != nil {
-		return err
-	}
-	if err := w.rs.Flush(ctx, tx, w.maxRowsPerStmt); err != nil {
-		return err
-	}
-	return index.InsertBatched(ctx, tx, "resource_history", historyCols, w.history, w.maxRowsPerStmt)
+	// Queue everything into one pipelined batch so the whole flush costs a
+	// single round trip instead of one per statement. Queue order preserves the
+	// FK ordering the sequential writes relied on: parent resources rows first,
+	// then the index DELETEs + INSERTs, then resource_history.
+	qb := &index.Batch{}
+	index.QueueInsertBatched(qb, "resources", resourcesCols, w.resources, w.maxRowsPerStmt)
+	w.rs.QueueFlush(qb, w.maxRowsPerStmt)
+	index.QueueInsertBatched(qb, "resource_history", historyCols, w.history, w.maxRowsPerStmt)
+	return qb.Send(ctx, tx)
 }
 
 // ─── Create ───────────────────────────────────────────────────────────────────
@@ -436,13 +438,15 @@ func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 	body["id"] = resourceID
 	body["resourceType"] = resourceType
 
-	newVersion, currentVersion, lastUpdated, err := bumpVersion(ctx, tx, resourceType, resourceID)
+	oldRaw, currentVersion, wasDeleted, err := lockForUpdate(ctx, tx, resourceType, resourceID)
 	if err != nil {
 		return nil, err
 	}
 	if ifMatchVersion >= 0 && currentVersion != ifMatchVersion {
 		return nil, ConflictError{fmt.Sprintf("version conflict: current=%d, if-match=%d", currentVersion, ifMatchVersion)}
 	}
+	newVersion := currentVersion + 1
+	lastUpdated := time.Now().UTC()
 
 	body = setMeta(body, newVersion, lastUpdated)
 	raw, err := json.Marshal(body)
@@ -453,8 +457,8 @@ func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 	// Update the resources row immediately so a later entry (or a subsequent
 	// version bump for the same id within this bundle) observes the new version.
 	// The stale index rows are cleared and the fresh ones inserted by the batched
-	// flush: AddDelete registers the re-index DELETE and drops any rows already
-	// buffered for this resource, then Extract buffers the new rows.
+	// flush; mergeReindex diffs the stored version's rows against the incoming
+	// version's so untouched sp_* tables cost nothing (see RowSet.MergeReindex).
 	if _, err := tx.Exec(ctx,
 		`UPDATE resources SET version_id = $1, last_updated = $2, resource_json = $3, is_deleted = FALSE
 		 WHERE fhir_id = $4 AND resource_type = $5 AND tenant_id = current_setting('app.current_tenant', true)`,
@@ -462,11 +466,42 @@ func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 	); err != nil {
 		return nil, err
 	}
-	w.rs.AddDelete(resourceType, resourceID)
-	s.extractor.Extract(w.rs, resourceType, resourceID, body, lastUpdated)
+	// A soft-deleted resource has no sp_* rows left, so its stored body must not
+	// contribute "old" rows — every table the new version touches gets a full
+	// (re)insert, exactly as a fresh create would.
+	if wasDeleted {
+		oldRaw = nil
+	}
+	s.mergeReindex(w, resourceType, resourceID, oldRaw, body, lastUpdated)
 	w.history = append(w.history, []any{w.tenant, resourceID, resourceType, newVersion, "PUT", raw, lastUpdated})
 
 	return body, nil
+}
+
+// mergeReindex buffers the re-index for one updated resource by diffing the
+// stored version's extracted rows (oldRaw; nil for none) against the incoming
+// body's. The old rows are extracted with the zero time: only tables without a
+// denormalised last_updated column are compared row-for-row, so the timestamp
+// never participates in the comparison, and mere table emptiness drives the
+// rest. If the stored JSON cannot be parsed it falls back to the full
+// clear-and-reinsert of every table.
+func (s *Store) mergeReindex(w *bundleWriter, resourceType, resourceID string, oldRaw []byte, body map[string]any, lastUpdated time.Time) {
+	// Unbounded (cap 0): the stored version already passed the row cap when it
+	// was written, and a LimitHit from re-extracting it must not abort this
+	// transaction — only the incoming version's rows count against the cap.
+	oldRS := index.NewRowSet(w.tenant, 0)
+	if len(oldRaw) > 0 {
+		var oldBody map[string]any
+		if err := json.Unmarshal(oldRaw, &oldBody); err != nil {
+			w.rs.AddDelete(resourceType, resourceID)
+			s.extractor.Extract(w.rs, resourceType, resourceID, body, lastUpdated)
+			return
+		}
+		s.extractor.Extract(oldRS, resourceType, resourceID, oldBody, time.Time{})
+	}
+	newRS := index.NewRowSet(w.tenant, w.maxRowsPerBundle)
+	s.extractor.Extract(newRS, resourceType, resourceID, body, lastUpdated)
+	w.rs.MergeReindex(oldRS, newRS, resourceType, resourceID)
 }
 
 // ─── Patch (JSON Merge Patch) ─────────────────────────────────────────────────
@@ -527,6 +562,11 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 	if err != nil {
 		return nil, 0, err
 	}
+	// Extract the stored version's index rows before mergePatch/setMeta run:
+	// both alias nested maps of existing, and the diff below must see the
+	// pre-patch rows.
+	oldRS := index.NewRowSet(w.tenant, 0)
+	s.extractor.Extract(oldRS, resourceType, resourceID, existing, time.Time{})
 	merged := mergePatch(existing, patch)
 	merged["id"] = resourceID
 	merged["resourceType"] = resourceType
@@ -539,8 +579,8 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 		return nil, 0, err
 	}
 
-	// Update immediately, then buffer the re-index (DELETE + fresh rows) and the
-	// history row for the batched flush — the same shape as updateInTx.
+	// Update immediately, then buffer the diffed re-index and the history row
+	// for the batched flush — the same shape as updateInTx.
 	if _, err := tx.Exec(ctx,
 		`UPDATE resources SET version_id = $1, last_updated = $2, resource_json = $3, is_deleted = FALSE
 		 WHERE fhir_id = $4 AND resource_type = $5 AND tenant_id = current_setting('app.current_tenant', true)`,
@@ -548,8 +588,9 @@ func (s *Store) patchInTx(ctx context.Context, tx pgx.Tx, resourceType, resource
 	); err != nil {
 		return nil, 0, err
 	}
-	w.rs.AddDelete(resourceType, resourceID)
-	s.extractor.Extract(w.rs, resourceType, resourceID, merged, now)
+	newRS := index.NewRowSet(w.tenant, w.maxRowsPerBundle)
+	s.extractor.Extract(newRS, resourceType, resourceID, merged, now)
+	w.rs.MergeReindex(oldRS, newRS, resourceType, resourceID)
 	w.history = append(w.history, []any{w.tenant, resourceID, resourceType, newVersion, "PATCH", mergedRaw, now})
 
 	return merged, newVersion, nil
@@ -635,12 +676,21 @@ func (s *Store) deleteInTx(ctx context.Context, tx pgx.Tx, resourceType, resourc
 	deleteVersion := versionID + 1
 	now := time.Now().UTC()
 
-	// Buffer the delete-history row and the re-index DELETE, then soft-delete the
-	// resources row immediately. The batched flush clears this resource's sp_*
-	// rows (AddDelete) and writes the history row; there are no fresh index rows
-	// for a delete.
+	// Buffer the delete-history row and the re-index DELETEs, then soft-delete
+	// the resources row immediately. The batched flush clears this resource's
+	// sp_* rows and writes the history row; there are no fresh index rows for a
+	// delete, so the diff (empty new side) scopes the DELETEs to just the tables
+	// the stored version actually has rows in. An unparseable stored body falls
+	// back to clearing every table.
 	w.history = append(w.history, []any{w.tenant, resourceID, resourceType, deleteVersion, "DELETE", raw, now})
-	w.rs.AddDelete(resourceType, resourceID)
+	var oldBody map[string]any
+	if err := json.Unmarshal(raw, &oldBody); err != nil {
+		w.rs.AddDelete(resourceType, resourceID)
+	} else {
+		oldRS := index.NewRowSet(w.tenant, 0)
+		s.extractor.Extract(oldRS, resourceType, resourceID, oldBody, time.Time{})
+		w.rs.MergeReindex(oldRS, index.NewRowSet(w.tenant, 0), resourceType, resourceID)
+	}
 	if _, err := tx.Exec(ctx,
 		`UPDATE resources SET is_deleted = TRUE, version_id = $1, last_updated = $2
 		 WHERE fhir_id = $3 AND resource_type = $4 AND tenant_id = current_setting('app.current_tenant', true)`,
@@ -824,18 +874,20 @@ func (s *Store) readInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceI
 	return unmarshalWithMeta(raw, versionID, lastUpdated)
 }
 
-func bumpVersion(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) (newVersion, currentVersion int, lastUpdated time.Time, err error) {
+// lockForUpdate locks the resource row and returns its stored body, version and
+// deletion flag. Fetching resource_json here costs nothing extra — the row is
+// already read for the lock — and it feeds the diff-based re-index, which needs
+// the stored version's extracted rows to decide which sp_* tables to touch.
+func lockForUpdate(ctx context.Context, tx pgx.Tx, resourceType, resourceID string) (raw []byte, currentVersion int, isDeleted bool, err error) {
 	if err = tx.QueryRow(ctx, `
-		SELECT version_id FROM resources WHERE fhir_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true) FOR UPDATE`,
+		SELECT resource_json, version_id, is_deleted FROM resources WHERE fhir_id = $1 AND resource_type = $2 AND tenant_id = current_setting('app.current_tenant', true) FOR UPDATE`,
 		resourceID, resourceType,
-	).Scan(&currentVersion); err != nil {
+	).Scan(&raw, &currentVersion, &isDeleted); err != nil {
 		if isNoRows(err) {
 			err = NotFoundError{resourceType, resourceID}
 		}
 		return
 	}
-	newVersion = currentVersion + 1
-	lastUpdated = time.Now().UTC()
 	return
 }
 


### PR DESCRIPTION
## Problem

With the recent search and write-path improvements in, resource **updates** are now the slowest CRUD operation. In an update-only k6 benchmark derived from the [HealthSamurai crud.js](https://github.com/HealthSamurai/fhir-server-performance-benchmark/blob/main/k6/crud.js) update mix (300 VUs, 3 min, 8-CPU server + 8-CPU Postgres 18, ~2M-resource dataset), PUTs averaged **127.8 ms** (p95 169 ms) at ~2,350 req/s, uniformly across all nine resource types — a trivial `Patient.gender` flip cost the same as a full `ExplanationOfBenefit` rewrite.

Profiling showed the latency is not query execution (only ~2.2 ms of SQL per update) but fixed per-request overhead:

1. **Full re-index on every PUT.** All 8 `sp_*` tables get an unconditional `DELETE` plus a complete reinsert of every extracted row (~11 rows for these resources), even when the update changed a single scalar. In the 3-minute window that was **3.37M DELETE statements** (8.0 per update, most matching zero rows) and ~4.8M reinserted index rows; sp_* index maintenance was ~85% of total DB execution time. `pg_stat_user_tables` showed the resulting churn feeding autovacuum and WAL continuously.
2. **~17 sequential round trips per transaction** (`set_config`, `SELECT … FOR UPDATE`, `UPDATE resources`, 8 DELETEs, up to 8 INSERTs, history INSERT). Wait-event sampling showed backends predominantly in `Client:ClientRead` — connections held mid-transaction while the server prepares the next statement — which throttles throughput at any pool size.

## Changes

**Diff-based re-index** (`updateInTx` / `patchInTx` / `deleteInTx`):

- `lockForUpdate` now fetches the stored `resource_json` in the *existing* `FOR UPDATE` select (no extra round trip) and the write paths diff the stored version's extracted rows against the incoming version's (`RowSet.MergeReindex`). Per table:
  - both versions have no rows → no statement at all (this was the common case for most of the 8 DELETEs);
  - `sp_string` / `sp_uri` — the tables **without** a denormalised `last_updated` column — are left completely untouched when their extracted rows are value-identical;
  - every other table still does the full clear-and-reinsert, because its rows embed `last_updated` and the covering recency scans in `search.go` serve that column in place of `resources.last_updated`, so it must stay fresh even when the indexed values didn't change.
- Re-index DELETEs are registered per **(table, resource)** instead of per resource, so untouched tables get no DELETE. Deletes scope to just the tables the stored version has rows in.
- A soft-deleted resource contributes no "old" rows, so undelete-via-PUT reinserts everything, exactly as before.

**Pipelined flush** (`bundleWriter.flush`, `index.Batch`):

- All buffered writes — deferred `resources` inserts, sp_* DELETEs + INSERTs, `resource_history` — are queued into one `pgx.SendBatch` and sent as a **single round trip**, preserving statement order (FK safety: parents before sp_* rows) and per-table error labels. This also benefits creates and bundle imports, which share the same flush.

## Results

Same update-only benchmark, same dataset, same hardware:

| Metric | Before (v0.6.50) | After | Δ |
|---|---|---|---|
| update latency avg | 127.8 ms | 77.7 ms | **−39%** |
| update latency p95 | 169 ms | 103 ms | −39% |
| update latency p99 | 236 ms | 136 ms | −42% |
| throughput | 2,347 req/s | 3,830 req/s | **+63%** |
| re-index DELETE statements / update | 8.0 | 2.8 | −65% |
| `sp_string` rows rewritten / update | ~3.4 | ~1.5 | −56% |

Checks passed 100% in both runs (~421k and ~688k PUTs respectively).

## Testing

- All unit tests pass; full `internal/store`, `internal/index`, and `internal/handler` integration suites pass (`-tags integration`).
- `TestBundleWritePath_StatementCount`'s tracer gained the pgx batch-tracer hooks (`TraceBatchQuery`) since flush statements now travel pipelined; its statement-budget assertions are unchanged and still hold.
- Live smoke-tested against the benchmark deployment: token-only update rewrites only the token row (fresh `last_updated`) and leaves `sp_string` untouched; string change rewrites string rows; PATCH, version history, vread, search freshness, DELETE (sp rows cleared), and undelete-via-PUT all behave identically to before.

## Notes for reviewers

- `rowsEqual` is order-sensitive by design: extraction is deterministic for a given body and registry, and any mismatch (e.g. array reordering) just falls back to the full re-index of that table — a missed optimisation, never a correctness issue.
- One behavioural nuance: previously, an update self-healed stale sp_* rows left by a since-removed `SearchParameter` definition via the blanket 8-table DELETE. With table-scoped deletes, rows in a table that the *current* registry no longer extracts for the old body would not be cleared on update. `DeleteSearchParameter` already clears its rows explicitly, so this only matters if index rows and registry drift out of sync through some other path.
- Follow-up levers deliberately left out of this PR: moving extraction ahead of `BEGIN` and collapsing the remaining round trips (`set_config` + lock select, `UPDATE` + flush) into two batches — backends still spend time in `Client:ClientRead`; and revisiting the `last_updated` denormalisation, which still forces ~7 rows/update of rewrite in the token/reference/date/quantity/composite tables.
