### PR TITLE
fix(store): use R4 containment semantics for date search

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,7 +784,7 @@ These checks apply to both `POST /{type}` (create), `PUT /{type}/{id}` (update),
 |---|---|---|---|
 | `string` | `family=smith` | `:exact`, `:contains`, `:missing` | Default is case-insensitive prefix match |
 | `token` | `gender=female`, `code=http://loinc.org\|8310-5` | `:missing`, `:in`, `:not-in`, `:below`, `:above` | `system\|code`, `\|code` (any system), `system\|` (any code with that system). The `:in`/`:not-in`/`:below`/`:above` modifiers require an external terminology server — see [Terminology](#10-terminology). |
-| `date` | `birthdate=ge1980`, `date=2024-01-15` | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `sa`, `eb`, `ap` | `eq` follows R4 containment semantics (the search range must fully contain the stored range); `ne` matches when the search range does not fully contain the stored range; `ap` matches on range overlap. Matching is per indexed value, so a resource with multiple values for one param can match both `eq` and `ne` |
+| `date` | `birthdate=ge1980`, `date=2024-01-15` | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `sa`, `eb`, `ap` | `eq` follows R4 containment semantics (the search range must fully contain the stored range); `ne` matches when the search range does not fully contain the stored range; `ap` matches on range overlap; `sa` matches values that start after the search range and `eb` matches values that end before it. Matching is per indexed value, so a resource with multiple values for one param can match both `eq` and `ne` |
 | `number` | `probability=gt0.8` | `eq`, `lt`, `gt` | |
 | `reference` | `subject=Patient/abc123` | — | |
 

--- a/README.md
+++ b/README.md
@@ -784,7 +784,7 @@ These checks apply to both `POST /{type}` (create), `PUT /{type}/{id}` (update),
 |---|---|---|---|
 | `string` | `family=smith` | `:exact`, `:contains`, `:missing` | Default is case-insensitive prefix match |
 | `token` | `gender=female`, `code=http://loinc.org\|8310-5` | `:missing`, `:in`, `:not-in`, `:below`, `:above` | `system\|code`, `\|code` (any system), `system\|` (any code with that system). The `:in`/`:not-in`/`:below`/`:above` modifiers require an external terminology server — see [Terminology](#10-terminology). |
-| `date` | `birthdate=ge1980`, `date=2024-01-15` | `eq`, `ne`, `lt`, `gt`, `le`, `ge` | `sa`/`eb` parse but fall back to `eq` |
+| `date` | `birthdate=ge1980`, `date=2024-01-15` | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `sa`, `eb`, `ap` | `eq` follows R4 containment semantics (the search range must fully contain the stored range); `ne` matches when the search range does not fully contain the stored range; `ap` matches on range overlap. Matching is per indexed value, so a resource with multiple values for one param can match both `eq` and `ne` |
 | `number` | `probability=gt0.8` | `eq`, `lt`, `gt` | |
 | `reference` | `subject=Patient/abc123` | — | |
 

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -250,7 +250,7 @@ CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (tenant_id, resource_id
 -- partition just to prove zero matches, paid twice (density probe + fetch). The
 -- GiST range index seeks both bounds at once: same query, 37 buffers / 0.69ms.
 -- buildDateExists emits the predicate as tstzrange(s.value_low, s.value_high,
--- '[]') <@ tstzrange(searchLow, searchHigh, '[]') for eq containment (&& for ap
+-- '[]') <@ tstzrange(searchLow, searchHigh, '[)') for eq containment (&& for ap
 -- overlap); the index expression below must stay byte-for-byte identical to that
 -- stored tstzrange or the planner will not match it. Identical pattern to
 -- idx_sp_qty_range_gist. The leading equality

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -250,9 +250,10 @@ CREATE INDEX IF NOT EXISTS idx_sp_date_source ON sp_date (tenant_id, resource_id
 -- partition just to prove zero matches, paid twice (density probe + fetch). The
 -- GiST range index seeks both bounds at once: same query, 37 buffers / 0.69ms.
 -- buildDateExists emits the predicate as tstzrange(s.value_low, s.value_high,
--- '[]') && tstzrange(searchLow, searchHigh, '[]'); the index expression below must
--- stay byte-for-byte identical to that stored tstzrange or the planner will not
--- match it. Identical pattern to idx_sp_qty_range_gist. The leading equality
+-- '[]') <@ tstzrange(searchLow, searchHigh, '[]') for eq containment (&& for ap
+-- overlap); the index expression below must stay byte-for-byte identical to that
+-- stored tstzrange or the planner will not match it. Identical pattern to
+-- idx_sp_qty_range_gist. The leading equality
 -- columns are varchar, which have no default gist opclass, hence btree_gist.
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 CREATE INDEX IF NOT EXISTS idx_sp_date_range_gist ON sp_date

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1584,7 +1584,17 @@ func (b *queryBuilder) buildDateExists(param, value string) string {
 	if col, op, useHigh, ok := halfBoundedColOp(prefix); ok {
 		bound := low
 		if useHigh {
-			bound = high
+			// High-side comparators run against the half-open band end used by
+			// eq/ne/ap, so the same stored value cannot be both inside the band and
+			// above it: inclusive ops against the old inclusive high become strict
+			// against the exclusive end, and vice versa (gt/sa > -> >=, le <= -> <).
+			bound = searchBandEnd(high)
+			switch op {
+			case ">":
+				op = ">="
+			case "<=":
+				op = "<"
+			}
 		}
 		cond = fmt.Sprintf("s.%s %s %s", col, op, b.next(bound))
 		if !b.suppressDirectDrive {
@@ -2634,6 +2644,10 @@ func quantizeBand(x float64) float64 { return math.Round(x*1e6) / 1e6 }
 // band's final fractional second (e.g. 23:59:59.9 on a day query) stays inside
 // the band; a fractional-second instant advances one microsecond (timestamptz
 // resolution) so the point itself stays covered without widening the band.
+// Treating fractional-second search values as points rather than expanding
+// their stated precision (a .500 millisecond value does not get a [.500, .501)
+// band) is a deliberate simplification, symmetric with the write side, which
+// also indexes instants as points.
 func searchBandEnd(high time.Time) time.Time {
 	if high.Nanosecond() == 0 {
 		return high.Add(time.Second)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -367,12 +367,15 @@ type densityProbe struct {
 	op2       string
 	bound2    any
 	// rangeCtor, when non-empty, names the range constructor (tstzrange) for a
-	// doubly bounded probe that should be emitted as a range-overlap predicate
-	// instead of two scalar bounds, so it seeks the GiST range index rather than
+	// doubly bounded probe that should be emitted as a range predicate instead of
+	// two scalar bounds, so it seeks the GiST range index rather than
 	// skip-scanning a btree on one bound with the other left as a filter. bound
-	// and bound2 are the search band's low and high. Mutually exclusive with the
-	// boundCol/boundCol2 scalar form.
+	// and bound2 are the search band's low and high, and rangeOp is the range
+	// operator the fetch uses ("<@" for eq containment, "&&" for ap overlap) —
+	// the probe must count the same rows the fetch will match. Mutually exclusive
+	// with the boundCol/boundCol2 scalar form.
 	rangeCtor string
+	rangeOp   string
 }
 
 type planVerdict int8
@@ -1589,12 +1592,21 @@ func (b *queryBuilder) buildDateExists(param, value string) string {
 		}
 	} else if prefix == "ne" {
 		lowP := b.next(low)
-		highP := b.next(high)
-		cond = fmt.Sprintf("NOT (%s && tstzrange(%s, %s, '[]'))", storedDateRange, lowP, highP)
-	} else { // eq, ap — doubly bounded interval overlap
+		highP := b.next(searchBandEnd(high))
+		// R4 ne: matches when the search range does not fully contain the stored range.
+		cond = fmt.Sprintf("NOT (%s <@ tstzrange(%s, %s, '[)'))", storedDateRange, lowP, highP)
+	} else { // eq, ap — doubly bounded range predicates
+		highX := searchBandEnd(high)
 		lowP := b.next(low)
-		highP := b.next(high)
-		cond = fmt.Sprintf("%s && tstzrange(%s, %s, '[]')", storedDateRange, lowP, highP)
+		highP := b.next(highX)
+		// R4 eq requires the search range to fully contain the stored range
+		// (search.html#prefix); ap matches on range overlap. The stored range sits
+		// on the left so both operators ride the idx_sp_date_range_gist expression.
+		rangeOp := "<@"
+		if prefix == "ap" {
+			rangeOp = "&&"
+		}
+		cond = fmt.Sprintf("%s %s tstzrange(%s, %s, '[)')", storedDateRange, rangeOp, lowP, highP)
 		// eq/ap are doubly bounded, so halfBoundedColOp cannot collapse them to one
 		// column — but a narrow band still needs a verdict. Without one the fetch
 		// falls through to the recency walk, and idx_sp_date_recent carries
@@ -1605,12 +1617,12 @@ func (b *queryBuilder) buildDateExists(param, value string) string {
 		// Restricted to narrow bands (see maxOverlapProbeBand): a wide low-precision
 		// band is dense enough that the walk already wins and must be left alone.
 		// rangeCtor makes the probe seek idx_sp_date_range_gist with the same
-		// overlap predicate the fetch uses, so proving a band sparse costs a GiST
+		// range predicate the fetch uses, so proving a band sparse costs a GiST
 		// descent rather than a btree skip-scan over half the partition.
-		if !b.suppressDirectDrive && high.Sub(low) <= maxOverlapProbeBand {
+		if !b.suppressDirectDrive && highX.Sub(low) <= maxOverlapProbeBand {
 			b.probe = &densityProbe{
 				table: "sp_date", rt: b.rt, param: param,
-				rangeCtor: "tstzrange", bound: low, bound2: high,
+				rangeCtor: "tstzrange", rangeOp: rangeOp, bound: low, bound2: highX,
 			}
 		}
 	}
@@ -2057,9 +2069,10 @@ func (b *queryBuilder) decidePlan(ctx context.Context, pool querier) error {
 	var pred string
 	args := []any{p.rt, p.param, p.bound}
 	if p.rangeCtor != "" {
-		// Range-overlap probe: byte-for-byte the fetch's predicate, so both ride
-		// the same GiST expression index (see storedDateRange / schema.sql).
-		pred = fmt.Sprintf("%s(s.value_low, s.value_high, '[]') && %s($3, $4, '[]')", p.rangeCtor, p.rangeCtor)
+		// Range probe: byte-for-byte the fetch's predicate (containment for eq,
+		// overlap for ap, half-open search band), so both ride the same GiST
+		// expression index (see storedDateRange / schema.sql).
+		pred = fmt.Sprintf("%s(s.value_low, s.value_high, '[]') %s %s($3, $4, '[)')", p.rangeCtor, p.rangeOp, p.rangeCtor)
 		args = append(args, p.bound2)
 	} else {
 		pred = fmt.Sprintf("s.%s %s $3", p.boundCol, p.op)
@@ -2614,6 +2627,19 @@ func extractComparatorPrefix(s string) (prefix, rest string) {
 // leaving the inclusive (ge/le) and doubly bounded (eq/ne) forms unaffected —
 // their boundaries carry a full 2·eps gap that rounding cannot flip.
 func quantizeBand(x float64) float64 { return math.Round(x*1e6) / 1e6 }
+
+// searchBandEnd converts the inclusive, second-truncated band high from
+// expandDateRange into the exclusive end of a half-open search band [low, end):
+// the next precision boundary for whole-second highs, so a stored value in the
+// band's final fractional second (e.g. 23:59:59.9 on a day query) stays inside
+// the band; a fractional-second instant advances one microsecond (timestamptz
+// resolution) so the point itself stays covered without widening the band.
+func searchBandEnd(high time.Time) time.Time {
+	if high.Nanosecond() == 0 {
+		return high.Add(time.Second)
+	}
+	return high.Add(time.Microsecond)
+}
 
 func expandDateRange(s string) (low, high time.Time) {
 	low, high, _ = expandDateStringForSearch(s)

--- a/internal/store/search_dateband_test.go
+++ b/internal/store/search_dateband_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSearchBandEnd(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		high time.Time
+		want time.Time
+	}{
+		{"day band high advances to the next day",
+			time.Date(2020, 6, 15, 23, 59, 59, 0, time.UTC),
+			time.Date(2020, 6, 16, 0, 0, 0, 0, time.UTC)},
+		{"whole-second instant covers its second",
+			time.Date(2020, 6, 15, 12, 0, 0, 0, time.UTC),
+			time.Date(2020, 6, 15, 12, 0, 1, 0, time.UTC)},
+		{"fractional-second instant stays a point at timestamptz resolution",
+			time.Date(2020, 6, 15, 12, 0, 0, 500_000_000, time.UTC),
+			time.Date(2020, 6, 15, 12, 0, 0, 500_001_000, time.UTC)},
+	} {
+		if got := searchBandEnd(tc.high); !got.Equal(tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestBuildDateExists_HalfOpenBandOps pins the comparator-to-column mapping
+// against the half-open search band: high-side comparators (gt/le/sa) bind the
+// exclusive band end with the adjusted operator, low-side ones (ge/lt/eb) bind
+// the band start unchanged, so no stored value can be simultaneously inside a
+// day's eq band and above it.
+func TestBuildDateExists_HalfOpenBandOps(t *testing.T) {
+	dayStart := time.Date(2020, 6, 15, 0, 0, 0, 0, time.UTC)
+	nextDay := time.Date(2020, 6, 16, 0, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		value string
+		frag  string
+		bound time.Time
+	}{
+		{"gt2020-06-15", "s.value_high >= $3", nextDay},
+		{"sa2020-06-15", "s.value_low >= $3", nextDay},
+		{"le2020-06-15", "s.value_low < $3", nextDay},
+		{"ge2020-06-15", "s.value_high >= $3", dayStart},
+		{"lt2020-06-15", "s.value_low < $3", dayStart},
+		{"eb2020-06-15", "s.value_high < $3", dayStart},
+	} {
+		b := &queryBuilder{rt: "Encounter"}
+		sql := b.buildDateExists("date", tc.value)
+		if !strings.Contains(sql, tc.frag) {
+			t.Errorf("%s: missing %q in:\n%s", tc.value, tc.frag, sql)
+		}
+		if got := b.args[2].(time.Time); !got.Equal(tc.bound) {
+			t.Errorf("%s: bound %v, want %v", tc.value, got, tc.bound)
+		}
+	}
+}

--- a/internal/store/search_probe_plan_test.go
+++ b/internal/store/search_probe_plan_test.go
@@ -143,16 +143,16 @@ func TestSearch_DensityProbe_Plan(t *testing.T) {
 	// one of value_low <= high / value_high >= low and leaves the other as a filter,
 	// so on the perf dataset an exact-instant eq skip-scanned 3.2k buffers / 19.7ms
 	// just to prove zero matches -- and paid it twice, once in the probe and once in
-	// the fetch. Both must now emit the identical tstzrange && tstzrange predicate,
+	// the fetch. Both must emit the identical tstzrange-on-the-left predicate,
 	// byte-for-byte matching the index expression, or the planner silently falls
-	// back to that skip-scan.
-	// 2099 keeps the band sparse: the seeded rows all span 2020, and an eq inside
-	// that band overlaps every one of them, where a seq scan of the fixture's 99
-	// pages is legitimately cheapest and the index assertion would be meaningless.
-	t.Run("date eq overlap seeks the gist range index", func(t *testing.T) {
+	// back to that skip-scan. eq is R4 containment (<@); ap is overlap (&&).
+	// 2099 keeps the band sparse: the seeded rows all span 2020, where a seq scan
+	// of the fixture's 99 pages is legitimately cheapest and the index assertion
+	// would be meaningless.
+	t.Run("date eq containment seeks the gist range index", func(t *testing.T) {
 		b, sql := build("Encounter", "date", "eq2099-06-15T12:00:00Z")
-		if !strings.Contains(sql, "tstzrange(s.value_low, s.value_high, '[]') &&") {
-			t.Errorf("eq date must emit the range-overlap predicate, got:\n%s", sql)
+		if !strings.Contains(sql, "tstzrange(s.value_low, s.value_high, '[]') <@") {
+			t.Errorf("eq date must emit the range-containment predicate, got:\n%s", sql)
 		}
 		plan := explain(b, sql)
 		if strings.Contains(plan, "Seq Scan on sp_date") {
@@ -163,10 +163,10 @@ func TestSearch_DensityProbe_Plan(t *testing.T) {
 		}
 	})
 
-	// The probe must use the same range-overlap predicate as the fetch, otherwise
+	// The probe must use the same range predicate as the fetch, otherwise
 	// proving a band sparse costs the very btree skip-scan the gist index exists to
 	// avoid. Asserted on the probe SQL directly, since decidePlan builds its own.
-	t.Run("date eq probe uses the range-overlap predicate", func(t *testing.T) {
+	t.Run("date eq probe uses the range-containment predicate", func(t *testing.T) {
 		b := &queryBuilder{rt: "Encounter", reg: reg}
 		b.writeBase()
 		b.applyParam("date", "eq2020-06-15T12:00:00Z")
@@ -179,18 +179,44 @@ func TestSearch_DensityProbe_Plan(t *testing.T) {
 		if b.probe.rangeCtor != "tstzrange" {
 			t.Errorf("expected rangeCtor tstzrange, got %q", b.probe.rangeCtor)
 		}
+		if b.probe.rangeOp != "<@" {
+			t.Errorf("eq probe must use containment, got %q", b.probe.rangeOp)
+		}
 		if b.probe.boundCol != "" || b.probe.boundCol2 != "" {
 			t.Errorf("range probe must not carry scalar bound columns, got %q/%q",
 				b.probe.boundCol, b.probe.boundCol2)
 		}
 	})
 
-	// ne is the complement of the same overlap and must stay consistent with eq:
-	// if the two drifted apart, eq and ne would no longer partition the match set.
-	t.Run("date ne emits the negated overlap", func(t *testing.T) {
+	// ne is the complement of the same containment and must stay consistent with
+	// eq: if the two drifted apart, eq and ne would no longer partition the match
+	// set.
+	t.Run("date ne emits the negated containment", func(t *testing.T) {
 		_, sql := build("Encounter", "date", "ne2020-06-15T12:00:00Z")
-		if !strings.Contains(sql, "NOT (tstzrange(s.value_low, s.value_high, '[]') &&") {
-			t.Errorf("ne date must emit the negated range-overlap predicate, got:\n%s", sql)
+		if !strings.Contains(sql, "NOT (tstzrange(s.value_low, s.value_high, '[]') <@") {
+			t.Errorf("ne date must emit the negated range-containment predicate, got:\n%s", sql)
+		}
+	})
+
+	// ap uses overlap semantics — approximate matching is range proximity, not
+	// containment — and must still ride the gist index expression.
+	t.Run("date ap uses the range-overlap predicate", func(t *testing.T) {
+		b, sql := build("Encounter", "date", "ap2099-06-15T12:00:00Z")
+		if !strings.Contains(sql, "tstzrange(s.value_low, s.value_high, '[]') &&") {
+			t.Errorf("ap date must emit the range-overlap predicate, got:\n%s", sql)
+		}
+		if b.probe == nil {
+			t.Fatal("expected a density probe for a narrow ap band")
+		}
+		if b.probe.rangeOp != "&&" {
+			t.Errorf("ap probe must use overlap, got %q", b.probe.rangeOp)
+		}
+		plan := explain(b, sql)
+		if strings.Contains(plan, "Seq Scan on sp_date") {
+			t.Errorf("date ap: unexpected seq scan:\n%s", plan)
+		}
+		if !strings.Contains(plan, "idx_sp_date_range_gist") {
+			t.Errorf("date ap: expected idx_sp_date_range_gist seek, got:\n%s", plan)
 		}
 	})
 

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1377,6 +1377,145 @@ func TestSearch_DatePeriodStraddle(t *testing.T) {
 	}
 }
 
+// TestSearch_DateEqContainment verifies R4 eq/ne semantics (search.html#prefix):
+// eq matches only when the search range fully contains the stored range, never
+// on mere overlap. With birthDates 2000, 2000-03 and 2000-03-13, a search for
+// the day must return only the day-precision patient — the year- and
+// month-precision bands overlap the day but are not contained in it. ne matches
+// when the search range does not fully contain the stored value. Membership by
+// id keeps the assertions independent of other seeded rows and of the plan the
+// density probe picks.
+func TestSearch_DateEqContainment(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	ids := map[string]string{}
+	for _, bd := range []string{"2000", "2000-03", "2000-03-13"} {
+		pat, err := s.Create(ctx, "Patient", map[string]any{
+			"resourceType": "Patient",
+			"birthDate":    bd,
+		})
+		if err != nil {
+			t.Fatalf("create patient birthDate=%s: %v", bd, err)
+		}
+		ids[bd], _ = pat["id"].(string)
+	}
+
+	matches := func(value, birthDate string) bool {
+		res, err := s.Search(ctx, store.SearchParams{
+			ResourceType: "Patient",
+			Params:       map[string][]string{"birthdate": {value}},
+		})
+		if err != nil {
+			t.Fatalf("search birthdate=%s: %v", value, err)
+		}
+		for _, e := range res.Entries {
+			if eid, _ := e["id"].(string); eid == ids[birthDate] {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, tc := range []struct {
+		value     string
+		birthDate string
+		want      bool
+	}{
+		// day-precision query contains only the day-precision band
+		{"2000-03-13", "2000", false},
+		{"2000-03-13", "2000-03", false},
+		{"2000-03-13", "2000-03-13", true},
+		// explicit eq is identical to the bare form
+		{"eq2000-03-13", "2000", false},
+		{"eq2000-03-13", "2000-03", false},
+		{"eq2000-03-13", "2000-03-13", true},
+		// month-precision query contains the month and the day, not the year
+		{"2000-03", "2000", false},
+		{"2000-03", "2000-03", true},
+		{"2000-03", "2000-03-13", true},
+		// year-precision query contains all three
+		{"2000", "2000", true},
+		{"2000", "2000-03", true},
+		{"2000", "2000-03-13", true},
+		// ne is the complement of eq's containment
+		{"ne2000-03-13", "2000", true},
+		{"ne2000-03-13", "2000-03", true},
+		{"ne2000-03-13", "2000-03-13", false},
+		{"ne2000", "2000", false},
+		{"ne2000", "2000-03-13", false},
+	} {
+		if got := matches(tc.value, tc.birthDate); got != tc.want {
+			t.Errorf("birthdate=%s vs stored %s: got match=%v, want %v",
+				tc.value, tc.birthDate, got, tc.want)
+		}
+	}
+}
+
+// TestSearch_DateEqPeriodContainment pins eq/ne containment for Period-valued
+// dates. The search band is half-open at the next precision boundary, so a
+// period ending in the day's final fractional second is still contained; a
+// period straddling the band is not; an open-ended period (indexed with a
+// sentinel high) is never contained in a bounded band.
+func TestSearch_DateEqPeriodContainment(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	create := func(period map[string]any) string {
+		enc, err := s.Create(ctx, "Encounter", map[string]any{
+			"resourceType": "Encounter", "status": "finished",
+			"class":  map[string]any{"system": "http://terminology.hl7.org/CodeSystem/v3-ActCode", "code": "AMB"},
+			"period": period,
+		})
+		if err != nil {
+			t.Fatalf("create encounter %v: %v", period, err)
+		}
+		id, _ := enc["id"].(string)
+		return id
+	}
+	fracID := create(map[string]any{"start": "2020-06-15T08:00:00Z", "end": "2020-06-15T23:59:59.900Z"})
+	spanID := create(map[string]any{"start": "2026-07-10T00:00:00Z", "end": "2026-07-12T00:00:00Z"})
+	openID := create(map[string]any{"start": "2026-08-01T00:00:00Z"})
+
+	matches := func(value, id string) bool {
+		res, err := s.Search(ctx, store.SearchParams{
+			ResourceType: "Encounter",
+			Params:       map[string][]string{"date": {value}},
+		})
+		if err != nil {
+			t.Fatalf("search date=%s: %v", value, err)
+		}
+		for _, e := range res.Entries {
+			if eid, _ := e["id"].(string); eid == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, tc := range []struct {
+		value string
+		id    string
+		want  bool
+	}{
+		// contained within the day, including its final fractional second
+		{"2020-06-15", fracID, true},
+		{"ne2020-06-15", fracID, false},
+		// a day inside the period overlaps but does not contain it
+		{"2026-07-11", spanID, false},
+		{"2026-07", spanID, true},
+		{"ne2026-07-11", spanID, true},
+		// open-ended period: sentinel high is never inside a bounded band
+		{"2026-08-01", openID, false},
+		{"2026", openID, false},
+		{"ne2026-08-01", openID, true},
+	} {
+		if got := matches(tc.value, tc.id); got != tc.want {
+			t.Errorf("date=%s vs %s: got match=%v, want %v", tc.value, tc.id, got, tc.want)
+		}
+	}
+}
+
 func TestSearch_ByReferenceParam(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()
@@ -1607,15 +1746,28 @@ func TestSearch_ObservationDateChoice(t *testing.T) {
 		t.Fatalf("exact date: got entries %v, want only %v", exact.Entries, dateTimeObservation["id"])
 	}
 
-	period, err := s.Search(ctx, store.SearchParams{
+	// A day inside the period merely overlaps it: eq containment must not match.
+	inside, err := s.Search(ctx, store.SearchParams{
 		ResourceType: "Observation",
 		Params:       map[string][]string{"date": {"2026-07-11"}},
 	})
 	if err != nil {
 		t.Fatalf("Search Observation period date: %v", err)
 	}
+	if inside.Total != 0 {
+		t.Fatalf("day inside period: got entries %v, want none", inside.Entries)
+	}
+
+	// The month band fully contains the period, so eq matches it.
+	period, err := s.Search(ctx, store.SearchParams{
+		ResourceType: "Observation",
+		Params:       map[string][]string{"date": {"2026-07"}},
+	})
+	if err != nil {
+		t.Fatalf("Search Observation period month: %v", err)
+	}
 	if period.Total != 1 || period.Entries[0]["id"] != periodObservation["id"] {
-		t.Fatalf("period date: got entries %v, want only %v", period.Entries, periodObservation["id"])
+		t.Fatalf("period month: got entries %v, want only %v", period.Entries, periodObservation["id"])
 	}
 
 	since, err := s.Search(ctx, store.SearchParams{

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1501,6 +1501,13 @@ func TestSearch_DateEqPeriodContainment(t *testing.T) {
 		// contained within the day, including its final fractional second
 		{"2020-06-15", fracID, true},
 		{"ne2020-06-15", fracID, false},
+		// half-bounded comparators agree with the band: inside the day is
+		// below its exclusive end, not above it, and after the prior day
+		{"le2020-06-15", fracID, true},
+		{"gt2020-06-15", fracID, false},
+		{"sa2020-06-14", fracID, true},
+		// ap keeps overlap: a day inside the period matches ap but not eq
+		{"ap2026-07-11", spanID, true},
 		// a day inside the period overlaps but does not contain it
 		{"2026-07-11", spanID, false},
 		{"2026-07", spanID, true},


### PR DESCRIPTION
Date `eq` searches now follow R4 containment semantics (search.html#prefix): the search range must fully contain the stored range. Previously `eq` matched on range overlap, so `Patient?birthdate=2000-03-13` also returned patients with `birthDate` `2000` or `2000-03`, whose implied ranges merely overlap the queried day. `ne` is now the negation of the same containment predicate, and `ap` keeps overlap.

The search band is half-open at the next precision boundary (`[low, nextBoundary)`, see `searchBandEnd`), so a stored value in the band's final fractional second - e.g. a period ending `23:59:59.9` on a day query - is still contained, and a seconds-precision instant query covers its whole second. The half-bounded comparators (`gt`, `le`, `sa`) compare against the same band end, so a value inside a day cannot simultaneously match `eq` and `gt` for that day. The density probe emits the identical predicate as the fetch so its verdict counts the same rows, and both sides still seek `idx_sp_date_range_gist` (`<@` is GiST-supported; plan-asserted in tests).

## Behavior change

Existing clients will see different results for date equality searches:

- Partial-precision stored dates no longer match finer-precision equality queries: `birthdate=2000-03-13` no longer returns patients with `birthDate` `2000` or `2000-03`.
- Open-ended periods (no `end`) no longer match any bounded `eq` search and always match `ne` - "ongoing encounter" style `eq` queries flip from matching to not matching.
- `ne` now returns resources whose range is not fully contained (it previously required no overlap), so `ne` result sets grow.
- Values in the final fractional second of a day now count as inside that day for `eq`/`le`, and no longer match `gt`/`sa` for it.

Fractional-second search values are treated as points at timestamptz resolution rather than expanded to their stated precision - a deliberate simplification, symmetric with the write side, noted on `searchBandEnd`.

Quantity/number/composite `eq`/`ne` still use overlap and are out of scope here; same for `ap`'s approximation window and `_filter`'s resource-level `ne`. Candidates for follow-ups.

Verified with the full unit, integration, and conformance suites, new coverage (`TestSearch_DateEqContainment`, `TestSearch_DateEqPeriodContainment`, `TestSearchBandEnd`, `TestBuildDateExists_HalfOpenBandOps`), and an end-to-end client run against a compose stack reproducing the partial-precision `birthdate` scenario.
