### PR TITLE
Support update-as-create (upsert) on PUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ Holds the core FHIR R4 resource StructureDefinitions (one row per resource type)
 | `GET` | `/{type}/{id}` | 200, 404, 410 | Read resource (410 if soft-deleted) |
 | `GET` | `/{type}/{id}/_history/{vid}` | 200, 400, 404 | Read specific version |
 | `POST` | `/{type}` | 201 | Create resource |
-| `PUT` | `/{type}/{id}` | 200, 400, 404, 412, 422 | Update resource |
+| `PUT` | `/{type}/{id}` | 200, 201, 400, 404, 412, 422 | Update resource (creates at the given id when missing — update-as-create; 404 only with `If-Match`) |
 | `PATCH` | `/{type}/{id}` | 200, 400, 404 | JSON Merge Patch (RFC 7396) |
 | `DELETE` | `/{type}/{id}` | 204, 404 | Soft delete |
 | `GET` | `/{type}` | 200 | Search |
@@ -532,12 +532,12 @@ Holds the core FHIR R4 resource StructureDefinitions (one row per resource type)
 | Header | Set on | Value |
 |---|---|---|
 | `ETag` | Read, Create, Update, Patch | `W/"<version_id>"` e.g. `W/"3"` |
-| `Location` | Create | `{baseURL}/{type}/{id}/_history/1` |
+| `Location` | Create, Update-as-create | `{baseURL}/{type}/{id}/_history/1` |
 | `Content-Type` | All responses | `application/fhir+json` |
 
 ### If-Match (optimistic locking)
 
-Send `If-Match: W/"<version>"` on `PUT` to enforce that you're updating the version you last read. Returns **412** if the current version differs.
+Send `If-Match: W/"<version>"` on `PUT` to enforce that you're updating the version you last read. Returns **412** if the current version differs, and **404** if the resource does not exist (a version precondition never triggers update-as-create).
 
 ```bash
 # Read current version

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Holds the core FHIR R4 resource StructureDefinitions (one row per resource type)
 |---|---|---|
 | `ETag` | Read, Create, Update, Patch | `W/"<version_id>"` e.g. `W/"3"` |
 | `Location` | Create, Update-as-create | `{baseURL}/{type}/{id}/_history/1` |
-| `Content-Type` | All responses | `application/fhir+json` |
+| `Content-Type` | All responses | `application/fhir+json` by default; `application/fhir+xml` or `application/fhir+turtle` when negotiated via `Accept`/`_format` |
 
 ### If-Match (optimistic locking)
 

--- a/internal/handler/bundle_integration_test.go
+++ b/internal/handler/bundle_integration_test.go
@@ -207,8 +207,8 @@ func TestIntegration_Transaction_ConditionalPutIfMatchZeroMatchFails(t *testing.
 	}
 
 	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
-	if resp.StatusCode == http.StatusOK {
-		t.Fatalf("expected transaction to fail, got 200")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404 for If-Match against a missing target, got %d", resp.StatusCode)
 	}
 	body := iJSON(t, resp)
 	if body["resourceType"] != "OperationOutcome" {
@@ -258,8 +258,8 @@ func TestIntegration_Batch_ConditionalPutIfMatchZeroMatchFailsEntry(t *testing.T
 		t.Errorf("sibling POST: want 201, got %q", status)
 	}
 	second, _ := entries[1].(map[string]any)["response"].(map[string]any)
-	if status, _ := second["status"].(string); strings.HasPrefix(status, "2") {
-		t.Errorf("conditional PUT with If-Match on zero matches must fail, got %q", status)
+	if status, _ := second["status"].(string); !strings.HasPrefix(status, "404") {
+		t.Errorf("conditional PUT with If-Match on zero matches must return 404, got %q", status)
 	}
 
 	// Nothing was created by the failing entry.

--- a/internal/handler/bundle_integration_test.go
+++ b/internal/handler/bundle_integration_test.go
@@ -178,6 +178,98 @@ func TestIntegration_Transaction_PutCreatesMissingResource(t *testing.T) {
 	rd.Body.Close()
 }
 
+// ─── Conditional update with If-Match: zero matches must not create ────────────
+
+func TestIntegration_Transaction_ConditionalPutIfMatchZeroMatchFails(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"fullUrl":  "urn:uuid:sibling",
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "IfMatchZeroMatch"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			// Conditional update that matches nothing but asserts a version via
+			// If-Match: the precondition cannot hold against a missing resource,
+			// so the entry must fail (not create) and roll the transaction back.
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "active": true},
+				"request": map[string]any{
+					"method":  "PUT",
+					"url":     "Patient?family=NoSuchFamilyAnywhere",
+					"ifMatch": "W/\"3\"",
+				},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected transaction to fail, got 200")
+	}
+	body := iJSON(t, resp)
+	if body["resourceType"] != "OperationOutcome" {
+		t.Fatalf("want OperationOutcome on failure, got %v", body["resourceType"])
+	}
+
+	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=IfMatchZeroMatch", nil)
+	sbody := iJSON(t, search)
+	if total, _ := sbody["total"].(float64); total != 0 {
+		t.Errorf("rollback failed: found %v sibling Patients that should not exist", total)
+	}
+}
+
+func TestIntegration_Batch_ConditionalPutIfMatchZeroMatchFailsEntry(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "batch",
+		"entry": []any{
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "name": []any{map[string]any{"family": "BatchIfMatchSibling"}}},
+				"request":  map[string]any{"method": "POST", "url": "Patient"},
+			},
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "active": true},
+				"request": map[string]any{
+					"method":  "PUT",
+					"url":     "Patient?family=NoSuchFamilyAnywhere",
+					"ifMatch": "W/\"3\"",
+				},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("batch: want 200, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	entries, _ := body["entry"].([]any)
+	if len(entries) != 2 {
+		t.Fatalf("want 2 response entries, got %d", len(entries))
+	}
+	first, _ := entries[0].(map[string]any)["response"].(map[string]any)
+	if status, _ := first["status"].(string); !strings.HasPrefix(status, "201") {
+		t.Errorf("sibling POST: want 201, got %q", status)
+	}
+	second, _ := entries[1].(map[string]any)["response"].(map[string]any)
+	if status, _ := second["status"].(string); strings.HasPrefix(status, "2") {
+		t.Errorf("conditional PUT with If-Match on zero matches must fail, got %q", status)
+	}
+
+	// Nothing was created by the failing entry.
+	search := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient?family=NoSuchFamilyAnywhere", nil)
+	sbody := iJSON(t, search)
+	if total, _ := sbody["total"].(float64); total != 0 {
+		t.Errorf("conditional PUT with If-Match created a resource: total=%v", total)
+	}
+}
+
 // ─── Batch: independent entries ────────────────────────────────────────────────
 
 func TestIntegration_Batch_IndependentEntries(t *testing.T) {

--- a/internal/handler/bundle_integration_test.go
+++ b/internal/handler/bundle_integration_test.go
@@ -141,6 +141,43 @@ func TestIntegration_Transaction_RollsBackOnError(t *testing.T) {
 	}
 }
 
+// ─── Transaction: update-as-create ─────────────────────────────────────────────
+
+func TestIntegration_Transaction_PutCreatesMissingResource(t *testing.T) {
+	srv := newRealServer(t)
+
+	bundle := map[string]any{
+		"resourceType": "Bundle",
+		"type":         "transaction",
+		"entry": []any{
+			map[string]any{
+				"resource": map[string]any{"resourceType": "Patient", "active": true},
+				"request":  map[string]any{"method": "PUT", "url": "Patient/upsert-in-txn"},
+			},
+		},
+	}
+
+	resp := iDo(t, srv, http.MethodPost, "/fhir/r4", bundle)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transaction: want 200, got %d", resp.StatusCode)
+	}
+	body := iJSON(t, resp)
+	entries, _ := body["entry"].([]any)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 response entry, got %d", len(entries))
+	}
+	entryResp, _ := entries[0].(map[string]any)["response"].(map[string]any)
+	if status, _ := entryResp["status"].(string); status != "201 Created" {
+		t.Errorf("want entry status 201 Created, got %q", status)
+	}
+
+	rd := iDo(t, srv, http.MethodGet, "/fhir/r4/Patient/upsert-in-txn", nil)
+	if rd.StatusCode != http.StatusOK {
+		t.Fatalf("read after PUT-create in transaction: want 200, got %d", rd.StatusCode)
+	}
+	rd.Body.Close()
+}
+
 // ─── Batch: independent entries ────────────────────────────────────────────────
 
 func TestIntegration_Batch_IndependentEntries(t *testing.T) {

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -36,6 +37,7 @@ type mockStore struct {
 	getVersionFn        func(ctx context.Context, rt, id string, vid int) (map[string]any, error)
 	createFn            func(ctx context.Context, rt string, body map[string]any) (map[string]any, error)
 	updateFn            func(ctx context.Context, rt, id string, body map[string]any, ifMatchVersion int) (map[string]any, error)
+	updateOrCreateFn    func(ctx context.Context, rt, id string, body map[string]any, ifMatchVersion int) (map[string]any, bool, error)
 	patchFn             func(ctx context.Context, rt, id string, patch map[string]any) (map[string]any, error)
 	deleteFn            func(ctx context.Context, rt, id string) error
 	getHistoryFn        func(ctx context.Context, rt, id string) ([]store.HistoryEntry, error)
@@ -60,6 +62,9 @@ func (m *mockStore) Create(ctx context.Context, rt string, body map[string]any) 
 }
 func (m *mockStore) Update(ctx context.Context, rt, id string, body map[string]any, ifMatchVersion int) (map[string]any, error) {
 	return m.updateFn(ctx, rt, id, body, ifMatchVersion)
+}
+func (m *mockStore) UpdateOrCreate(ctx context.Context, rt, id string, body map[string]any, ifMatchVersion int) (map[string]any, bool, error) {
+	return m.updateOrCreateFn(ctx, rt, id, body, ifMatchVersion)
 }
 func (m *mockStore) Patch(ctx context.Context, rt, id string, patch map[string]any) (map[string]any, error) {
 	return m.patchFn(ctx, rt, id, patch)
@@ -138,6 +143,28 @@ func doWithCT(t *testing.T, h http.Handler, method, path string, body any, conte
 	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
 	if body != nil {
 		req.Header.Set("Content-Type", contentType)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func doWithHeaders(t *testing.T, h http.Handler, method, path string, body any, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/fhir+json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -284,9 +311,9 @@ func TestCreate_InvalidJSON(t *testing.T) {
 
 func TestUpdate_Success(t *testing.T) {
 	ms := &mockStore{}
-	ms.updateFn = func(_ context.Context, rt, id string, body map[string]any, _ int) (map[string]any, error) {
+	ms.updateOrCreateFn = func(_ context.Context, rt, id string, body map[string]any, _ int) (map[string]any, bool, error) {
 		body["meta"] = map[string]any{"versionId": "2"}
-		return body, nil
+		return body, false, nil
 	}
 
 	h := newRouter(ms)
@@ -297,15 +324,40 @@ func TestUpdate_Success(t *testing.T) {
 	}
 }
 
-func TestUpdate_NotFound(t *testing.T) {
+func TestUpdate_CreatesWhenMissing(t *testing.T) {
 	ms := &mockStore{}
-	ms.updateFn = func(_ context.Context, rt, id string, _ map[string]any, _ int) (map[string]any, error) {
-		return nil, store.NotFoundError{ResourceType: rt, ResourceID: id}
+	ms.updateOrCreateFn = func(_ context.Context, rt, id string, body map[string]any, _ int) (map[string]any, bool, error) {
+		body["meta"] = map[string]any{"versionId": "1"}
+		return body, true, nil
+	}
+
+	h := newRouter(ms)
+	payload := map[string]any{"resourceType": "Patient", "id": "new-id", "active": true}
+	w := do(t, h, http.MethodPut, "/fhir/r4/Patient/new-id", payload)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); !strings.HasSuffix(loc, "/Patient/new-id/_history/1") {
+		t.Errorf("want Location ending in /Patient/new-id/_history/1, got %q", loc)
+	}
+	if et := w.Header().Get("ETag"); et != `W/"1"` {
+		t.Errorf(`want ETag W/"1", got %q`, et)
+	}
+}
+
+func TestUpdate_IfMatchMissingResourceIs404(t *testing.T) {
+	ms := &mockStore{}
+	ms.updateOrCreateFn = func(_ context.Context, rt, id string, _ map[string]any, ifMatchVersion int) (map[string]any, bool, error) {
+		if ifMatchVersion != 2 {
+			t.Errorf("want ifMatchVersion=2 passed through, got %d", ifMatchVersion)
+		}
+		return nil, false, store.NotFoundError{ResourceType: rt, ResourceID: id}
 	}
 
 	h := newRouter(ms)
 	payload := map[string]any{"resourceType": "Patient", "id": "missing"}
-	w := do(t, h, http.MethodPut, "/fhir/r4/Patient/missing", payload)
+	w := doWithHeaders(t, h, http.MethodPut, "/fhir/r4/Patient/missing", payload,
+		map[string]string{"If-Match": `W/"2"`})
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", w.Code)
 	}

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -748,7 +748,7 @@ func (h *fhirHandler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resource, err := h.store.Update(r.Context(), rt, id, body, ifMatchVersion)
+	resource, created, err := h.store.UpdateOrCreate(r.Context(), rt, id, body, ifMatchVersion)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -759,6 +759,11 @@ func (h *fhirHandler) update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("ETag", fmt.Sprintf(`W/"%s"`, versionFromMeta(resource)))
+	if created {
+		w.Header().Set("Location", fmt.Sprintf("%s/%s/%s/_history/1", h.tenantBaseURL(r.Context()), rt, id))
+		writeFHIR(w, r, http.StatusCreated, resource)
+		return
+	}
 	writeFHIR(w, r, http.StatusOK, resource)
 }
 
@@ -1353,7 +1358,7 @@ func (h *fhirHandler) metadata(w http.ResponseWriter, r *http.Request) {
 			},
 			"versioning":        "versioned",
 			"readHistory":       true,
-			"updateCreate":      false,
+			"updateCreate":      true,
 			"conditionalCreate": true,
 			"conditionalUpdate": true,
 			"conditionalDelete": "single",

--- a/internal/handler/store.go
+++ b/internal/handler/store.go
@@ -29,6 +29,7 @@ type StoreAPI interface {
 	GetVersion(ctx context.Context, resourceType, resourceID string, versionID int) (map[string]any, error)
 	Create(ctx context.Context, resourceType string, body map[string]any) (map[string]any, error)
 	Update(ctx context.Context, resourceType, resourceID string, body map[string]any, ifMatchVersion int) (map[string]any, error)
+	UpdateOrCreate(ctx context.Context, resourceType, resourceID string, body map[string]any, ifMatchVersion int) (map[string]any, bool, error)
 	Patch(ctx context.Context, resourceType, resourceID string, patch map[string]any) (map[string]any, error)
 	Delete(ctx context.Context, resourceType, resourceID string) error
 	GetHistory(ctx context.Context, resourceType, resourceID string) ([]store.HistoryEntry, error)

--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -87,7 +87,6 @@ type bundleOp struct {
 	ifMatch      int        // parsed If-Match version, or -1 for none
 	query        url.Values // GET search / conditional delete filter
 	isSearch     bool       // GET against a type (search) vs GET of an instance (read)
-	allowCreate  bool       // conditional update matched 0 resources — PUT creates at the assigned id
 
 	// conditional-create / -update that matched an existing resource: no write
 	// is performed and the entry resolves to the matched resource.
@@ -255,10 +254,10 @@ func (s *Store) runOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp, w *bundle
 		if err != nil {
 			// A missing target creates the resource at the requested id (FHIR
 			// "update as create"): a conditional update that matched zero
-			// resources (allowCreate), or a plain PUT to a new id. A PUT with an
-			// If-Match precondition never creates — the version check against a
-			// missing resource stays a 404, which rolls the transaction back.
-			if _, ok := err.(NotFoundError); ok && (op.allowCreate || op.ifMatch < 0) {
+			// resources, or a plain PUT to a new id. A PUT with an If-Match
+			// precondition never creates — the version check against a missing
+			// resource stays a 404, which rolls the transaction back.
+			if _, ok := err.(NotFoundError); ok && op.ifMatch < 0 {
 				op.body["id"] = op.id
 				// Write this created row immediately (deferResource=false): the
 				// conditional target id may be referenced by a later entry.
@@ -498,7 +497,6 @@ func (s *Store) planOps(ctx context.Context, baseURL string, entries []BundleEnt
 					op.id = existingID
 				} else {
 					op.id = assignedID(e.Resource) // create with a fresh (or body-supplied) id
-					op.allowCreate = true
 				}
 			}
 			if op.id == "" {

--- a/internal/store/bundle.go
+++ b/internal/store/bundle.go
@@ -87,7 +87,7 @@ type bundleOp struct {
 	ifMatch      int        // parsed If-Match version, or -1 for none
 	query        url.Values // GET search / conditional delete filter
 	isSearch     bool       // GET against a type (search) vs GET of an instance (read)
-	allowCreate  bool       // PUT may create when the target is missing (conditional update, 0 matches)
+	allowCreate  bool       // conditional update matched 0 resources — PUT creates at the assigned id
 
 	// conditional-create / -update that matched an existing resource: no write
 	// is performed and the entry resolves to the matched resource.
@@ -253,10 +253,12 @@ func (s *Store) runOpInTx(ctx context.Context, tx pgx.Tx, op bundleOp, w *bundle
 	case "PUT":
 		res, err := s.updateInTx(ctx, tx, op.resourceType, op.id, op.body, op.ifMatch, w)
 		if err != nil {
-			// A conditional update that matched zero resources creates the target;
-			// a plain PUT to a missing id is a 404 (the server does not do
-			// update-as-create), which in a transaction rolls everything back.
-			if _, ok := err.(NotFoundError); ok && op.allowCreate {
+			// A missing target creates the resource at the requested id (FHIR
+			// "update as create"): a conditional update that matched zero
+			// resources (allowCreate), or a plain PUT to a new id. A PUT with an
+			// If-Match precondition never creates — the version check against a
+			// missing resource stays a 404, which rolls the transaction back.
+			if _, ok := err.(NotFoundError); ok && (op.allowCreate || op.ifMatch < 0) {
 				op.body["id"] = op.id
 				// Write this created row immediately (deferResource=false): the
 				// conditional target id may be referenced by a later entry.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -430,6 +430,45 @@ func (s *Store) Update(ctx context.Context, resourceType, resourceID string, bod
 	return result, nil
 }
 
+// UpdateOrCreate replaces a resource, creating it at the given id when no
+// resource exists there (FHIR "update as create"). The created return reports
+// which of the two happened, so the handler can answer 201 instead of 200.
+// A version precondition (ifMatchVersion >= 0) never creates: If-Match asserts
+// the client has seen a specific version, so a missing target stays a
+// NotFoundError exactly as in Update.
+func (s *Store) UpdateOrCreate(ctx context.Context, resourceType, resourceID string, body map[string]any, ifMatchVersion int) (map[string]any, bool, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	defer tx.Rollback(ctx)
+
+	if err := setTenantTx(ctx, tx); err != nil {
+		return nil, false, err
+	}
+
+	w := s.newBundleWriter(ctx)
+	created := false
+	result, err := s.updateInTx(ctx, tx, resourceType, resourceID, body, ifMatchVersion, w)
+	if _, missing := err.(NotFoundError); missing && ifMatchVersion < 0 {
+		created = true
+		result, err = s.createInTx(ctx, tx, resourceType, body, w, false)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if err := w.flush(ctx, tx); err != nil {
+		return nil, false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, false, err
+	}
+
+	slog.Debug("upserted resource", "type", resourceType, "id", resourceID, "created", created, "version", metaVersionID(result))
+	return result, created, nil
+}
+
 // updateInTx performs an update within an existing transaction. Shared by the
 // public Update and by transaction/batch Bundle processing.
 func (s *Store) updateInTx(ctx context.Context, tx pgx.Tx, resourceType, resourceID string, body map[string]any, ifMatchVersion int, w *bundleWriter) (map[string]any, error) {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -226,6 +226,76 @@ func TestUpdate_NotFound(t *testing.T) {
 	}
 }
 
+func TestUpdateOrCreate_CreatesWhenMissing(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	res, created, err := s.UpdateOrCreate(ctx, "Patient", "client-chosen-id", map[string]any{
+		"resourceType": "Patient",
+		"active":       true,
+	}, -1)
+	if err != nil {
+		t.Fatalf("UpdateOrCreate: %v", err)
+	}
+	if !created {
+		t.Error("expected created=true for a missing id")
+	}
+	if res["id"] != "client-chosen-id" {
+		t.Errorf("expected id=client-chosen-id, got %v", res["id"])
+	}
+	meta := res["meta"].(map[string]any)
+	if meta["versionId"] != "1" {
+		t.Errorf("expected versionId=1, got %v", meta["versionId"])
+	}
+
+	// The created resource must be readable and searchable like any other.
+	got, err := s.Read(ctx, "Patient", "client-chosen-id")
+	if err != nil {
+		t.Fatalf("Read after update-as-create: %v", err)
+	}
+	if got["active"] != true {
+		t.Errorf("expected active=true, got %v", got["active"])
+	}
+}
+
+func TestUpdateOrCreate_UpdatesExisting(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	created, _ := s.Create(ctx, "Patient", map[string]any{
+		"resourceType": "Patient",
+		"active":       true,
+	})
+	id := created["id"].(string)
+
+	res, wasCreated, err := s.UpdateOrCreate(ctx, "Patient", id, map[string]any{
+		"resourceType": "Patient",
+		"id":           id,
+		"active":       false,
+	}, -1)
+	if err != nil {
+		t.Fatalf("UpdateOrCreate: %v", err)
+	}
+	if wasCreated {
+		t.Error("expected created=false for an existing id")
+	}
+	meta := res["meta"].(map[string]any)
+	if meta["versionId"] != "2" {
+		t.Errorf("expected versionId=2, got %v", meta["versionId"])
+	}
+}
+
+func TestUpdateOrCreate_IfMatchNeverCreates(t *testing.T) {
+	s := newStore(t)
+	_, _, err := s.UpdateOrCreate(context.Background(), "Patient", "ghost-id", map[string]any{
+		"resourceType": "Patient",
+	}, 2)
+	var nfe store.NotFoundError
+	if !errors.As(err, &nfe) {
+		t.Fatalf("expected NotFoundError when If-Match targets a missing resource, got %T: %v", err, err)
+	}
+}
+
 // ─── Patch ────────────────────────────────────────────────────────────────────
 
 func TestPatch_MergesFields(t *testing.T) {


### PR DESCRIPTION
## Summary

`PUT /{type}/{id}` for an id that does not exist now creates the resource at that id and returns **201 Created** with a `Location` header, implementing the FHIR R4 update interaction's optional [update-as-create](https://hl7.org/fhir/R4/http.html#upsert) behavior. Previously such a PUT returned 404, which also made transaction bundles that seed fixtures via PUT (a common pattern in conformance suites and ETL pipelines) fail outright.

A PUT carrying an `If-Match` precondition never creates: a version check against a missing resource still returns 404, and a failing entry still rolls a transaction bundle back.

## Changes

- **store**: new `UpdateOrCreate` — runs `updateInTx` and, on `NotFoundError` with no version precondition, falls back to `createInTx` at the requested id within the same transaction, returning a `created` flag. The public `Update` keeps strict update semantics for the PATCH and conditional-update flows.
- **bundle**: transaction/batch `PUT` entries to a missing id create (entry response `201 Created`) instead of failing, unless the entry carries `ifMatch`. Reuses the create fallback that already existed for conditional updates matching zero resources.
- **handler**: PUT answers 201 with `Location: {base}/{type}/{id}/_history/1` and `ETag: W/"1"` when the write created; the CapabilityStatement now advertises `"updateCreate": true`.
- **README**: PUT status codes and If-Match notes updated.

## Testing

- New integration tests: `TestUpdateOrCreate_CreatesWhenMissing`, `TestUpdateOrCreate_UpdatesExisting`, `TestUpdateOrCreate_IfMatchNeverCreates`, `TestIntegration_Transaction_PutCreatesMissingResource`.
- New/updated handler tests: 201 + `Location`/`ETag` on create; If-Match against a missing resource stays 404.
- `go test ./...` and `go test -tags integration ./internal/store ./internal/handler` pass.
- Measured against the [fhir262](https://github.com/HealthSamurai/fhir262) conformance suite (which seeds fixtures via PUT): passing tests rose from 141/1572 to 1313/1572; the interval-search suite went from 0/1240 (all failing at fixture setup) to 1172/1240.