### PR TITLE
docs: add Mintlify docs site

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,6 @@
+README.md
+DESIGN.md
+CONTRIBUTING.md
+SECURITY.md
+TESTING.md
+.github/

--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "aspen",
+  "name": "WSO2 FHIR Server",
+  "description": "Documentation for the WSO2 FHIR R4 Server",
+  "colors": {
+    "primary": "#F36C21",
+    "light": "#FF8A4C",
+    "dark": "#C94F0C"
+  },
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "icon": "book-open",
+        "groups": [
+          {
+            "group": "Welcome",
+            "pages": [
+              "docs/index"
+            ]
+          },
+          {
+            "group": "Get started",
+            "pages": [
+              "docs/get-started/introduction",
+              "docs/get-started/quickstart",
+              "docs/get-started/installation"
+            ]
+          },
+          {
+            "group": "Core concepts",
+            "pages": [
+              "docs/concepts/architecture",
+              "docs/concepts/storage",
+              "docs/concepts/multi-tenancy"
+            ]
+          },
+          {
+            "group": "Platform capabilities",
+            "pages": [
+              "docs/guides/implementation-guides",
+              "docs/guides/terminology",
+              "docs/guides/validation"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Reference",
+        "icon": "brackets-curly",
+        "groups": [
+          {
+            "group": "FHIR API",
+            "pages": [
+              "docs/reference/api",
+              "docs/reference/search",
+              "docs/reference/configuration"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Operations",
+        "icon": "server",
+        "groups": [
+          {
+            "group": "Run the server",
+            "pages": [
+              "docs/operations/deployment",
+              "docs/operations/health-and-observability",
+              "docs/performance-tuning"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Development",
+        "icon": "code",
+        "groups": [
+          {
+            "group": "Contribute",
+            "pages": [
+              "docs/development/testing",
+              "docs/development/extending",
+              "docs/development/contributing"
+            ]
+          }
+        ]
+      }
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/wso2/fhir-server",
+          "icon": "github"
+        },
+        {
+          "anchor": "WSO2",
+          "href": "https://wso2.com/",
+          "icon": "globe"
+        }
+      ]
+    }
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "FHIR R4",
+        "href": "https://hl7.org/fhir/R4/"
+      }
+    ],
+    "primary": {
+      "type": "github",
+      "href": "https://github.com/wso2/fhir-server"
+    }
+  },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "cursor",
+      "vscode"
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/wso2/fhir-server"
+    }
+  }
+}

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -1,0 +1,64 @@
+---
+title: Architecture
+description: Understand the request lifecycle and boundaries of the WSO2 FHIR Server.
+icon: diagram-project
+---
+
+# How requests move through the server
+
+WSO2 FHIR Server is a single Go service connected to PostgreSQL. HTTP handlers coordinate storage, validation, search, indexing, and terminology integrations through focused internal packages.
+
+```mermaid
+flowchart LR
+    Client["FHIR client"] --> Router["HTTP router and handlers"]
+    Router --> Validate["Validation"]
+    Router --> Store["Resource store"]
+    Router --> Search["Search builder"]
+    Store --> Index["Search extraction"]
+    Search --> Registry["Search parameter registry"]
+    Index --> FHIRPath["FHIRPath evaluator"]
+    Store --> DB[("PostgreSQL")]
+    Search --> DB
+    Index --> DB
+    Router --> TX["Terminology service"]
+    IG["FHIR packages"] --> Registry
+    IG --> Validate
+```
+
+## Package responsibilities
+
+| Package | Responsibility |
+| --- | --- |
+| `cmd/server` | Configuration, dependency wiring, startup, and shutdown |
+| `internal/handler` | Routing, content negotiation, FHIR interactions, and OperationOutcome responses |
+| `internal/store` | CRUD, transactions, history, versioning, and SQL query construction |
+| `internal/index` | Write-time extraction into typed search tables |
+| `internal/fhirpath` | FHIRPath parsing and evaluation |
+| `internal/validate` | Base structural and profile validation |
+| `internal/ig` | Implementation Guide package loading |
+| `internal/terminology` | External terminology calls and closure bookkeeping |
+| `internal/tenant` | Tenant resolution and PostgreSQL tenant scope |
+
+## Write lifecycle
+
+1. The router resolves the tenant and negotiates the FHIR representation.
+2. The handler decodes the resource and applies configured validation.
+3. The store opens a PostgreSQL transaction and sets the tenant scope.
+4. The current resource is created or updated and its version advances.
+5. An immutable history snapshot is appended.
+6. Search values are extracted and the resource's `sp_*` rows are refreshed.
+7. The transaction commits all changes atomically.
+
+## Search lifecycle
+
+1. The handler parses query parameters and resolves the tenant.
+2. The search registry determines each parameter's type and expression.
+3. The store builds predicates against the corresponding `sp_*` tables.
+4. PostgreSQL identifies and orders matching resource IDs.
+5. The full JSON documents are loaded and returned in a searchset Bundle.
+
+## Startup lifecycle
+
+The service loads configuration, connects to PostgreSQL, prepares the schema when explicitly enabled, seeds base R4 definitions, and initializes the search registry. Implementation Guides can load during startup; readiness remains closed until required initialization completes.
+
+For design rationale and accepted tradeoffs, read [`DESIGN.md`](https://github.com/wso2/fhir-server/blob/main/DESIGN.md).

--- a/docs/concepts/multi-tenancy.mdx
+++ b/docs/concepts/multi-tenancy.mdx
@@ -1,0 +1,59 @@
+---
+title: Multi-tenancy
+description: Choose between physically isolated and logically isolated tenant deployments.
+icon: building
+---
+
+# Choose an isolation boundary
+
+WSO2 FHIR Server supports two deployment patterns. Choose the isolation boundary before provisioning data or exposing client URLs.
+
+## Dedicated server and database
+
+Run one server and one PostgreSQL database for each tenant.
+
+**Use this model when:**
+
+- Regulatory or contractual requirements demand physical separation.
+- Tenants need independent scaling, maintenance, backup, or retention policies.
+- Operational simplicity is more important than infrastructure consolidation.
+
+The FHIR base URL does not require a tenant path:
+
+```text
+https://tenant.example.com/fhir/r4
+```
+
+## Shared server and database
+
+Run one service and database while scoping data with a tenant identifier and PostgreSQL row-level security.
+
+Tenant-aware routes use:
+
+```text
+/t/{tenant}/fhir/r4
+```
+
+For example:
+
+```bash
+curl -sS "http://localhost:9090/t/acme/fhir/r4/Patient"
+```
+
+The server sets the tenant scope on each transaction before accessing protected tables.
+
+<Warning>
+  A URL tenant identifier is routing context, not proof of identity or authorization. Place an authenticated gateway or equivalent security layer in front of the service and bind the authenticated tenant to the routed tenant value.
+</Warning>
+
+## Selection guide
+
+| Concern | Dedicated | Shared |
+| --- | --- | --- |
+| Data isolation | Infrastructure boundary | Database policy boundary |
+| Scaling | Per tenant | Shared capacity |
+| Upgrades | Independent | Coordinated |
+| Backup and restore | Per tenant | Requires tenant-aware procedures |
+| Operational overhead | Higher | Lower |
+
+Validate backups, connection pooling, privileged database access, and cross-tenant negative tests for the selected model.

--- a/docs/concepts/storage.mdx
+++ b/docs/concepts/storage.mdx
@@ -1,0 +1,58 @@
+---
+title: Storage model
+description: Learn how FHIR resources, history, and search values are represented in PostgreSQL.
+icon: database
+---
+
+# Storage model
+
+All FHIR resource types share one primary table. Searchable values are projected into typed relational indexes at write time.
+
+## Core tables
+
+| Table | Purpose |
+| --- | --- |
+| `resources` | Current JSONB representation and metadata for every resource |
+| `resource_history` | Immutable snapshots for versioned reads and history |
+| `sp_*` | Typed search values extracted from resources |
+| `search_param_definitions` | Base, IG-provided, and custom SearchParameter definitions |
+| `ig_packages` | Loaded FHIR package records |
+| `ig_profiles` | StructureDefinitions available for profile validation |
+| `base_definitions` | Base FHIR R4 StructureDefinitions |
+| `schema_version` | Applied schema revision |
+
+## Resource identity
+
+The current representation is identified by tenant, FHIR resource type, and logical ID. Metadata tracks the current version and last-updated instant. Deletes are soft deletes so history remains available.
+
+## Version history
+
+Creates, updates, and deletes append a complete resource snapshot to `resource_history`. This supports:
+
+- Version-specific reads with `/_history/{version}`.
+- Instance and type history interactions.
+- Optimistic concurrency with weak ETags and `If-Match`.
+- Audit and reconciliation workflows at the resource-store level.
+
+## Search indexes
+
+The server does not scan arbitrary JSON for normal FHIR search. It stores extracted values in tables shaped for FHIR matching semantics:
+
+- `sp_string`
+- `sp_token`
+- `sp_date`
+- `sp_number`
+- `sp_quantity`
+- `sp_uri`
+- `sp_reference`
+- `sp_coords`
+
+This shifts work to writes and produces bounded, index-oriented reads. Resource storage, history, and index refreshes share the same transaction.
+
+<Note>
+  A full-document JSONB GIN index is intentionally absent. Search is implemented through the typed indexes, while full-text behavior uses the dedicated search vector.
+</Note>
+
+## Schema management
+
+The canonical schema is [`internal/db/schema.sql`](https://github.com/wso2/fhir-server/blob/main/internal/db/schema.sql). It is idempotent, but production deployments should apply schema changes out of band with a controlled database role.

--- a/docs/development/contributing.mdx
+++ b/docs/development/contributing.mdx
@@ -1,0 +1,49 @@
+---
+title: Contributing
+description: Prepare focused, tested contributions to WSO2 FHIR Server.
+icon: code-pull-request
+---
+
+# Contribute to WSO2 FHIR Server
+
+## Prepare the repository
+
+```bash
+git clone https://github.com/wso2/fhir-server.git
+cd fhir-server
+make build
+make test
+```
+
+Required development tools include Go 1.25 or later and PostgreSQL 14 or later. Docker can provide the database used by integration tests.
+
+## Development workflow
+
+1. Fork the repository and branch from an up-to-date `main`.
+2. Keep the change focused and add regression coverage.
+3. Run formatting, vet, lint, and unit tests.
+4. Run integration tests for database-backed behavior.
+5. Open a pull request against `main` and complete the repository template.
+
+## Code conventions
+
+- Format Go with `gofmt`.
+- Wrap errors with context using `fmt.Errorf("...: %w", err)`.
+- Include the repository's Apache 2.0 header in new Go files.
+- Keep comments focused on non-obvious reasoning.
+- Place unit tests next to the code under test.
+- Use the `integration` build tag for PostgreSQL integration tests.
+
+## Before opening a pull request
+
+```bash
+make fmt
+make vet
+make lint
+make test
+make test-integration
+```
+
+Document any check that could not be run and why. Do not report security vulnerabilities through a public issue; follow [`SECURITY.md`](https://github.com/wso2/fhir-server/blob/main/SECURITY.md).
+
+The complete contribution policy is in [`CONTRIBUTING.md`](https://github.com/wso2/fhir-server/blob/main/CONTRIBUTING.md).

--- a/docs/development/extending.mdx
+++ b/docs/development/extending.mdx
@@ -1,0 +1,49 @@
+---
+title: Extend the server
+description: Add validation, search, FHIR operations, and schema changes within existing boundaries.
+icon: puzzle-piece
+---
+
+# Extend the server
+
+Keep extensions within the package that owns the behavior and preserve the atomic resource, history, and index write contract.
+
+## Add validation behavior
+
+Validation belongs in `internal/validate`. Add focused tests for valid, invalid, absent, and choice-type values. Return structured OperationOutcome issues through the handler layer.
+
+## Add a search parameter type
+
+A new parameter type normally requires coordinated changes to:
+
+1. SearchParameter parsing and registry typing.
+2. FHIRPath extraction in `internal/index`.
+3. PostgreSQL schema and indexes.
+4. Query construction in `internal/store`.
+5. Unit and PostgreSQL integration tests.
+6. Reindex guidance for existing resources.
+
+Prefer registering new parameters through FHIR SearchParameter resources or Implementation Guides when the existing type system already supports their behavior.
+
+## Add a FHIR operation
+
+Implement routing and FHIR response behavior in `internal/handler`, then place reusable domain or storage logic in the appropriate internal package. Cover:
+
+- Instance, type, or system-level route semantics.
+- GET and POST forms when required by FHIR.
+- Parameters input and output resources.
+- OperationOutcome failures.
+- Tenant scope and transaction boundaries.
+
+## Change the database schema
+
+Edit `internal/db/schema.sql` and keep provisioning idempotent. Consider existing deployments separately from clean database creation. Schema changes need PostgreSQL integration tests and a documented rollout path.
+
+## Preserve design constraints
+
+- Do not query arbitrary resource JSON when a typed search index owns the behavior.
+- Do not write history or search rows outside the resource transaction.
+- Do not silently broaden a query when a predicate cannot be evaluated correctly.
+- Keep terminology reasoning behind the terminology integration boundary.
+
+Read [`DESIGN.md`](https://github.com/wso2/fhir-server/blob/main/DESIGN.md) before changing a cross-cutting contract.

--- a/docs/development/testing.mdx
+++ b/docs/development/testing.mdx
@@ -1,0 +1,63 @@
+---
+title: Testing
+description: Run unit, race, integration, and quality checks for the FHIR server.
+icon: flask
+---
+
+# Test the server
+
+Use the repository Make targets so local checks match continuous integration.
+
+## Unit tests
+
+Unit tests do not require PostgreSQL or Docker:
+
+```bash
+make test
+```
+
+The unit suite runs with the race detector. To invoke Go directly:
+
+```bash
+go test -race ./...
+```
+
+## Integration tests
+
+Integration tests require Docker and use the `integration` build tag:
+
+```bash
+make test-integration
+```
+
+They exercise PostgreSQL-backed behavior, including storage, search, transactions, history, and tenant isolation.
+
+## Quality checks
+
+```bash
+make fmt
+make vet
+make lint
+make test
+```
+
+Run integration tests when a change touches handlers, the store, indexing, search, schema, tenancy, or another database-backed path.
+
+## Focused Go tests
+
+```bash
+go test -race ./internal/fhirpath/...
+go test -race ./internal/handler/...
+go test -race ./internal/store/...
+```
+
+## Testing changes safely
+
+- Add the smallest focused regression test that proves the behavior.
+- Test both success and OperationOutcome failure paths.
+- Include tenant separation cases for tenant-aware code.
+- Verify index extraction and query behavior together when changing search.
+- Test transaction rollback when changing Bundle processing.
+- Use realistic partial precision, modifiers, and choice-type fields for FHIR search cases.
+
+See [`TESTING.md`](https://github.com/wso2/fhir-server/blob/main/TESTING.md) for the repository's detailed testing model.

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -1,0 +1,60 @@
+---
+title: Installation
+description: Build and run WSO2 FHIR Server as a binary or container.
+icon: download
+---
+
+# Install and run the server
+
+## Build a binary
+
+**Prerequisite:** Go 1.25 or later.
+
+```bash
+go build -o fhir-server ./cmd/server
+```
+
+## Build a container image
+
+```bash
+docker build -t fhir-server:latest .
+```
+
+## Prepare PostgreSQL
+
+The server supports PostgreSQL 14 through 18. Create a database and runtime role, then apply the idempotent schema:
+
+```bash
+psql "postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable" \
+  -f internal/db/schema.sql
+```
+
+Alternatively, set `FHIR_CREATE_TABLES=true` for a one-time startup using a role with DDL privileges.
+
+<Warning>
+  Keep DDL privileges out of the steady-state runtime role. Provision the schema separately for production deployments.
+</Warning>
+
+## Run with a configuration file
+
+```bash
+cp config.example.yaml config.yaml
+./fhir-server --config ./config.yaml
+```
+
+## Run with environment variables
+
+```bash
+export DATABASE_URL="postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable"
+export SERVER_PORT=9090
+export BASE_URL="http://localhost:9090/fhir/r4"
+./fhir-server
+```
+
+Configuration precedence is:
+
+```text
+environment variable > configuration file > built-in default
+```
+
+See the complete [configuration reference](/docs/reference/configuration) before deploying the server.

--- a/docs/get-started/introduction.mdx
+++ b/docs/get-started/introduction.mdx
@@ -1,0 +1,43 @@
+---
+title: Introduction
+description: Learn what WSO2 FHIR Server provides and how its main components fit together.
+icon: handshake
+---
+
+# What is WSO2 FHIR Server?
+
+WSO2 FHIR Server is an open-source FHIR R4 REST server optimized for a compact operational footprint and a predictable PostgreSQL data model. It replaces per-resource relational tables with one JSONB resource store and a small set of typed search-index tables.
+
+## What it provides
+
+- FHIR create, read, update, patch, delete, versioned read, and history interactions.
+- FHIR search across string, token, date, number, quantity, URI, reference, and composite parameters.
+- Transaction and batch Bundle processing.
+- CapabilityStatement generation and `$validate` support.
+- Implementation Guide package loading and profile-aware validation.
+- External terminology integration for ValueSet and CodeSystem operations.
+- Physical and logical multi-tenant deployment models.
+
+## Design priorities
+
+<CardGroup cols={2}>
+  <Card title="One schema" icon="database">
+    All FHIR resource types share the same resource and history tables. New types and profiles do not require per-resource migrations.
+  </Card>
+  <Card title="Indexed search" icon="magnifying-glass">
+    Search predicates resolve through narrow typed indexes. Resource JSON is fetched only after matches are identified.
+  </Card>
+  <Card title="Atomic writes" icon="shield-check">
+    Resource storage, version history, and search-index refreshes commit in the same PostgreSQL transaction.
+  </Card>
+  <Card title="Explicit boundaries" icon="route">
+    Terminology is delegated to a terminology server, while deployment-specific identity and policy remain infrastructure concerns.
+  </Card>
+</CardGroup>
+
+## Where to begin
+
+1. Use the [Docker Compose quickstart](/docs/get-started/quickstart) for the shortest path to a running server.
+2. Read [Architecture](/docs/concepts/architecture) before changing shared behavior.
+3. Use the [FHIR API reference](/docs/reference/api) when integrating a client.
+4. Review [Deployment](/docs/operations/deployment) before running outside a local environment.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -1,0 +1,81 @@
+---
+title: Quickstart
+description: Start the server with Docker Compose and create your first FHIR resource.
+icon: rocket
+---
+
+# Run the server with Docker Compose
+
+## Prerequisites
+
+- Docker Desktop, Docker Engine, or Colima
+- `curl`
+- `jq` for the response examples
+
+## Start the stack
+
+From the repository root:
+
+```bash
+docker-compose up
+```
+
+The stack starts:
+
+| Service | Address |
+| --- | --- |
+| FHIR base URL | `http://localhost:9090/fhir/r4` |
+| Readiness endpoint | `http://localhost:9090/health/ready` |
+| Adminer | `http://localhost:8080` |
+| PostgreSQL | `localhost:5432` |
+
+Wait until readiness returns `200 OK`:
+
+```bash
+curl -sv http://localhost:9090/health/ready
+```
+
+## Create a Patient
+
+```bash
+curl -sS -X POST http://localhost:9090/fhir/r4/Patient \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Patient",
+    "name": [{"family": "Smith", "given": ["Alice"]}]
+  }' | jq
+```
+
+The server assigns an `id`, sets version metadata, and returns the created Patient.
+
+## Search for the Patient
+
+```bash
+curl -sS "http://localhost:9090/fhir/r4/Patient?family=Smith" | jq
+```
+
+The response is a FHIR searchset Bundle.
+
+## Inspect PostgreSQL
+
+Open `http://localhost:8080` and use:
+
+| Field | Value |
+| --- | --- |
+| System | PostgreSQL |
+| Server | `db` |
+| Username | `fhir` |
+| Password | `fhir` |
+| Database | `fhirdb` |
+
+<Warning>
+  These credentials are local development defaults. Do not reuse them in a shared or production environment.
+</Warning>
+
+## Stop and remove local data
+
+```bash
+docker-compose down -v
+```
+
+Continue with [Installation](/docs/get-started/installation) to run the binary directly or build a container image.

--- a/docs/guides/implementation-guides.mdx
+++ b/docs/guides/implementation-guides.mdx
@@ -1,0 +1,57 @@
+---
+title: Implementation Guides
+description: Load FHIR packages and expose their profiles through the server.
+icon: layer-group
+---
+
+# FHIR Implementation Guides
+
+The server can load FHIR npm packages at startup. Loaded packages contribute profiles and search definitions used by validation and the generated CapabilityStatement.
+
+## Configure packages
+
+In `config.yaml`:
+
+```yaml
+ig:
+  packages:
+    - hl7.fhir.us.core@6.1.0
+    - hl7.fhir.us.carin-bb@2.0.0
+  registryUrl: https://packages.fhir.org
+  forceReload: false
+  cacheDir: .fhir-ig-cache
+```
+
+Or use environment variables:
+
+```bash
+export IG_PACKAGES="hl7.fhir.us.core@6.1.0,hl7.fhir.us.carin-bb@2.0.0"
+export IG_REGISTRY_URL="https://packages.fhir.org"
+```
+
+Package entries may use `name@version` or a direct `.tgz` URL.
+
+## Startup behavior
+
+For each configured package, the loader:
+
+1. Resolves and downloads the package when it is not cached.
+2. Extracts relevant StructureDefinitions and SearchParameters.
+3. Stores package and profile metadata in PostgreSQL.
+4. Updates the in-memory registries used by validation and search.
+
+Previously loaded packages are skipped unless `IG_FORCE_RELOAD=true`.
+
+## Verify loaded profiles
+
+Read the server CapabilityStatement:
+
+```bash
+curl -sS http://localhost:9090/fhir/r4/metadata | jq
+```
+
+Check the reported implementation guides, supported profiles, and search parameters.
+
+<Tip>
+  Pin package versions. An unpinned package source makes startup behavior and validation rules harder to reproduce across environments.
+</Tip>

--- a/docs/guides/terminology.mdx
+++ b/docs/guides/terminology.mdx
@@ -1,0 +1,38 @@
+---
+title: Terminology
+description: Connect the FHIR server to an external terminology service.
+icon: tags
+---
+
+# Terminology integration
+
+WSO2 FHIR Server stores clinical resources but delegates terminology reasoning to a FHIR terminology service. This keeps ValueSet expansion, code validation, and subsumption outside the resource-store runtime.
+
+## Configure the service
+
+Set the terminology base URL through the server configuration supported by your deployment. For local evaluation, use a non-production terminology endpoint and verify its licensing and availability constraints.
+
+## Terminology-backed search
+
+Token searches can use terminology modifiers when the external service is configured. Examples include ValueSet membership and CodeSystem hierarchy searches:
+
+```bash
+curl -sS --get "http://localhost:9090/fhir/r4/Observation" \
+  --data-urlencode "code:in=http://example.org/fhir/ValueSet/lab-codes"
+```
+
+```bash
+curl -sS --get "http://localhost:9090/fhir/r4/Condition" \
+  --data-urlencode "code:below=http://snomed.info/sct|73211009"
+```
+
+## Operational considerations
+
+- Treat the terminology service as a runtime dependency for terminology-backed queries.
+- Set explicit timeouts and monitor error rates and latency.
+- Confirm CodeSystem and ValueSet licensing for every deployment.
+- Cache only where the terminology server's versioning semantics make cached results safe.
+
+<Warning>
+  Do not assume the public terminology sandbox provides production availability, performance, or licenses for every code system.
+</Warning>

--- a/docs/guides/validation.mdx
+++ b/docs/guides/validation.mdx
@@ -1,0 +1,44 @@
+---
+title: Validation
+description: Understand structural and profile validation behavior.
+icon: shield-check
+---
+
+# Validate FHIR resources
+
+The server validates basic FHIR resource structure and can apply loaded profile constraints when profile validation is enabled.
+
+## Use `$validate`
+
+Validate a resource without storing it:
+
+```bash
+curl -sS -X POST "http://localhost:9090/fhir/r4/Observation/$validate" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Observation",
+    "status": "final",
+    "code": {"text": "Heart rate"}
+  }' | jq
+```
+
+The response is an OperationOutcome:
+
+- `200 OK` when validation succeeds.
+- `422 Unprocessable Entity` when the resource violates an applicable rule.
+
+## Validation on write
+
+Base resource checks protect fundamental structure. Profile validation is deployment-controlled and applies to profiles declared in `meta.profile` when their StructureDefinitions are available.
+
+<Note>
+  The default behavior favors FHIR interoperability. Load the required Implementation Guides and enable the corresponding validation policy when a deployment requires profile enforcement.
+</Note>
+
+## Profile availability
+
+Use `/metadata` to confirm that the expected packages and profiles loaded successfully before sending profile-constrained traffic.
+
+## Application behavior
+
+Clients should parse OperationOutcome issues instead of relying only on HTTP status text. Preserve the issue severity, code, diagnostics, and expression fields when presenting validation failures.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,55 @@
+---
+title: WSO2 FHIR Server
+description: A production-oriented FHIR R4 REST server built in Go and backed by PostgreSQL.
+icon: heart-pulse
+mode: wide
+---
+
+# Build on a focused FHIR R4 foundation
+
+WSO2 FHIR Server stores, validates, searches, and versions FHIR R4 resources through a standards-aligned REST API. It is a single Go binary backed by PostgreSQL, with a normalized search index designed for predictable query performance.
+
+<CardGroup cols={3}>
+  <Card title="Run it locally" icon="rocket" href="/docs/get-started/quickstart">
+    Start PostgreSQL and the server with Docker Compose, then create your first Patient.
+  </Card>
+  <Card title="Understand the design" icon="diagram-project" href="/docs/concepts/architecture">
+    Follow requests from the HTTP API through validation, storage, indexing, and search.
+  </Card>
+  <Card title="Use the FHIR API" icon="brackets-curly" href="/docs/reference/api">
+    Work with CRUD, history, transactions, validation, search, and FHIR operations.
+  </Card>
+</CardGroup>
+
+## At a glance
+
+| Capability | Implementation |
+| --- | --- |
+| FHIR version | R4 (4.0.1) |
+| Runtime | Go 1.25 |
+| Database | PostgreSQL 14 through 18 |
+| Resource model | JSONB resources with normalized typed search indexes |
+| API formats | FHIR JSON, XML, and Turtle where supported |
+| Tenancy | Dedicated deployments or logical tenant isolation |
+| Extensibility | Custom SearchParameters and FHIR Implementation Guides |
+
+## Choose your path
+
+<CardGroup cols={2}>
+  <Card title="Application developer" icon="code">
+    Start with the [quickstart](/docs/get-started/quickstart), then use the [API reference](/docs/reference/api) and [search guide](/docs/reference/search).
+  </Card>
+  <Card title="Platform operator" icon="server">
+    Review [configuration](/docs/reference/configuration), [deployment](/docs/operations/deployment), and [performance tuning](/docs/performance-tuning).
+  </Card>
+  <Card title="FHIR implementer" icon="file-medical">
+    Learn how [Implementation Guides](/docs/guides/implementation-guides), [validation](/docs/guides/validation), and [terminology](/docs/guides/terminology) work.
+  </Card>
+  <Card title="Contributor" icon="code-pull-request">
+    Read the [testing](/docs/development/testing), [extension](/docs/development/extending), and [contribution](/docs/development/contributing) guides.
+  </Card>
+</CardGroup>
+
+<Note>
+  This project implements FHIR server capabilities. Always validate deployment-specific security, consent, audit, retention, and compliance requirements before handling health information.
+</Note>

--- a/docs/operations/deployment.mdx
+++ b/docs/operations/deployment.mdx
@@ -1,0 +1,63 @@
+---
+title: Deployment
+description: Prepare the server and PostgreSQL for a controlled deployment.
+icon: server
+---
+
+# Prepare a controlled deployment
+
+The server ships as a Go binary and container image. A production deployment also needs PostgreSQL, schema provisioning, ingress and identity controls, backups, secrets, monitoring, and a deliberate tenant model.
+
+## Deployment checklist
+
+1. Build an immutable binary or container from a reviewed commit.
+2. Provision a supported PostgreSQL version and apply `internal/db/schema.sql` with a controlled DDL role.
+3. Create a least-privileged runtime database role.
+4. Store database credentials and other secrets outside the image and repository.
+5. Set `BASE_URL` to the canonical externally reachable FHIR base URL.
+6. Configure read, write, idle, client, ingress, and database timeouts coherently.
+7. Put TLS and authenticated authorization enforcement in front of the service.
+8. Configure readiness and liveness probes separately.
+9. Establish backup, restore, retention, and disaster-recovery procedures.
+10. Run smoke, search, tenancy, and restore tests before accepting traffic.
+
+## Container
+
+```bash
+docker build -t fhir-server:latest .
+```
+
+Pass runtime configuration through environment variables or mount a YAML configuration file. Do not bake credentials into the image.
+
+## Database provisioning
+
+Apply the schema separately:
+
+```bash
+psql "$DATABASE_URL" -f internal/db/schema.sql
+```
+
+`FHIR_CREATE_TABLES=true` is intended for controlled first-start or local workflows, not as a default runtime privilege.
+
+## Network and identity boundary
+
+The FHIR server handles FHIR resources and tenant-scoped storage. Deploy an API gateway, service mesh, or equivalent enforcement point for:
+
+- TLS termination and certificate policy.
+- Authentication and token validation.
+- Tenant binding and authorization.
+- Rate limits and abuse controls.
+- Network allowlists and request-size controls.
+- Security audit integration.
+
+## Timeouts
+
+`SERVER_WRITE_TIMEOUT` bounds the entire handler execution from the HTTP server's perspective. Large transaction Bundles can exceed the default. Measure the largest supported request under expected concurrency, then coordinate the server, proxy, client, and database timeout budgets.
+
+<Warning>
+  A client-side EOF during a long transaction Bundle can represent an indeterminate outcome. Reconcile resource state before retrying.
+</Warning>
+
+## After bulk loading
+
+Run `VACUUM (ANALYZE)` on `resources` and the search-parameter tables after a bulk import. This refreshes visibility maps and planner statistics before serving search traffic.

--- a/docs/operations/health-and-observability.mdx
+++ b/docs/operations/health-and-observability.mdx
@@ -1,0 +1,54 @@
+---
+title: Health and observability
+description: Monitor startup, readiness, logs, and critical dependencies.
+icon: waveform
+---
+
+# Health and observability
+
+Use separate liveness and readiness signals so an orchestrator can distinguish a running process from an instance ready to accept FHIR traffic.
+
+## Health endpoints
+
+Check readiness:
+
+```bash
+curl -i http://localhost:9090/health/ready
+```
+
+A `200 OK` response indicates required initialization has completed. During startup, Implementation Guide loading and registry preparation can keep readiness closed after the listener is available.
+
+## Structured logs
+
+The server writes JSON logs to standard output. Configure verbosity with `LOG_LEVEL`:
+
+```bash
+LOG_LEVEL=info ./fhir-server
+```
+
+The listening log includes the effective address and FHIR base URL:
+
+```json
+{"level":"INFO","msg":"server listening","addr":":9090","baseURL":"http://localhost:9090/fhir/r4"}
+```
+
+Startup logs also report effective search tuning. Confirm the logged values when applying environment overrides.
+
+## What to monitor
+
+- HTTP request volume, latency, response classes, and OperationOutcome error codes.
+- Readiness state and restart frequency.
+- PostgreSQL connections, lock waits, statement latency, replication, disk, and autovacuum.
+- Search latency by resource type and parameter class.
+- Transaction Bundle duration and rejection counts.
+- Implementation Guide load failures.
+- External terminology latency and failures.
+- Cross-tenant access-denial tests in shared deployments.
+
+## Correlation
+
+Preserve request correlation identifiers at the ingress and include them in downstream logs where the deployment stack supports it. Avoid logging resource bodies or sensitive query values by default.
+
+<Warning>
+  FHIR resources and search parameters can contain protected health information. Apply data minimization and access controls to logs, traces, metrics labels, and error reporting systems.
+</Warning>

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -1,10 +1,15 @@
-# Performance Tuning
+---
+title: Performance tuning
+description: Tune search planning, PostgreSQL, and the bulk-write path using measured workload behavior.
+icon: gauge-high
+---
+
+# Tune with measured workload behavior
 
 > **Scope.** This document covers the **search layer** — the density-probe
 > architecture and the knobs around it. For hardware sizing (storage IOPS, the
 > memory budget under a container limit), PostgreSQL server settings, and the
-> write/import path, see [Performance Tuning](../README.md#14-performance-tuning) in
-> the README.
+> write/import path, see [Performance Tuning in the repository guide](https://github.com/wso2/fhir-server/blob/main/README.md#14-performance-tuning).
 > Tune in that order — storage, then PostgreSQL, then these knobs. No search knob
 > rescues a saturated disk.
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -1,0 +1,119 @@
+---
+title: FHIR REST API
+description: Reference for resource interactions, history, Bundles, and server operations.
+icon: brackets-curly
+---
+
+# Interact with FHIR resources
+
+The default FHIR base URL is:
+
+```text
+http://localhost:9090/fhir/r4
+```
+
+Use `application/fhir+json` for the examples below. The server also negotiates supported FHIR XML and Turtle representations.
+
+## Interactions
+
+| Interaction | Method and path |
+| --- | --- |
+| Create | `POST /{type}` |
+| Read | `GET /{type}/{id}` |
+| Update | `PUT /{type}/{id}` |
+| Patch | `PATCH /{type}/{id}` |
+| Delete | `DELETE /{type}/{id}` |
+| Search | `GET /{type}?{parameters}` |
+| Search with form body | `POST /{type}/_search` |
+| Versioned read | `GET /{type}/{id}/_history/{version}` |
+| Instance history | `GET /{type}/{id}/_history` |
+| Type history | `GET /{type}/_history` |
+| System transaction or batch | `POST /` |
+| CapabilityStatement | `GET /metadata` |
+| Validate | `POST /{type}/$validate` |
+| Resource graph | `GET /{type}/{id}/$everything` |
+
+## Create
+
+```bash
+curl -i -X POST "http://localhost:9090/fhir/r4/Patient" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Patient",
+    "active": true,
+    "name": [{"family": "Smith", "given": ["Alice"]}]
+  }'
+```
+
+A successful create returns `201 Created`, the created resource, a `Location` header, and a weak ETag.
+
+## Read and update
+
+```bash
+curl -sS "http://localhost:9090/fhir/r4/Patient/{id}" | jq
+```
+
+```bash
+curl -i -X PUT "http://localhost:9090/fhir/r4/Patient/{id}" \
+  -H "Content-Type: application/fhir+json" \
+  -H 'If-Match: W/"1"' \
+  -d '{
+    "resourceType": "Patient",
+    "id": "{id}",
+    "active": true
+  }'
+```
+
+`If-Match` enables optimistic locking. A stale version fails instead of overwriting a concurrent update.
+
+## Patch
+
+JSON Patch is supported through the FHIR resource endpoint:
+
+```bash
+curl -i -X PATCH "http://localhost:9090/fhir/r4/Patient/{id}" \
+  -H "Content-Type: application/json-patch+json" \
+  -d '[{"op":"replace","path":"/active","value":false}]'
+```
+
+## Delete
+
+```bash
+curl -i -X DELETE "http://localhost:9090/fhir/r4/Patient/{id}"
+```
+
+A successful delete returns `204 No Content`. The resource is soft-deleted and the version remains available through history.
+
+## Transaction Bundle
+
+```bash
+curl -sS -X POST "http://localhost:9090/fhir/r4" \
+  -H "Content-Type: application/fhir+json" \
+  -d '{
+    "resourceType": "Bundle",
+    "type": "transaction",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:patient-1",
+        "resource": {
+          "resourceType": "Patient",
+          "name": [{"family": "Smith"}]
+        },
+        "request": {"method": "POST", "url": "Patient"}
+      }
+    ]
+  }' | jq
+```
+
+Transaction entries commit atomically. Batch entries produce independent outcomes.
+
+## Response metadata
+
+Resource responses can include:
+
+- `Content-Type` with the negotiated FHIR media type.
+- `ETag` containing the weak resource version.
+- `Last-Modified` containing the resource update time.
+- `Location` identifying a newly created version.
+
+Errors use a FHIR OperationOutcome body whenever the response can be represented as FHIR.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -1,0 +1,117 @@
+---
+title: Configuration
+description: Configure the server, database, search, write path, and Implementation Guide loader.
+icon: sliders
+---
+
+# Configuration reference
+
+The server reads YAML, environment variables, or both. Higher-priority sources override lower-priority sources:
+
+```text
+environment variable > configuration file > built-in default
+```
+
+Pass a file explicitly:
+
+```bash
+fhir-server --config /etc/fhir-server/config.yaml
+```
+
+Or set:
+
+```bash
+FHIR_SERVER_CONFIG=/etc/fhir-server/config.yaml fhir-server
+```
+
+Unknown keys, invalid values, and an explicitly configured missing file fail startup.
+
+## Example
+
+```yaml
+server:
+  port: 9090
+  baseUrl: http://localhost:9090/fhir/r4
+  readTimeout: 30s
+  writeTimeout: 60s
+  idleTimeout: 120s
+
+logging:
+  level: info
+
+database:
+  url: postgres://fhir:fhir@localhost:5432/fhirdb?sslmode=disable
+  createTables: false
+  planCacheMode: force_custom_plan
+
+search:
+  probeCap: 5000
+  defaultPageSize: 20
+  maxPageSize: 200
+  maxChainDepth: 5
+
+write:
+  maxRowsPerStatement: 1000
+  maxRowsPerBundle: 100000
+
+ig:
+  packages:
+    - hl7.fhir.us.core@6.1.0
+  registryUrl: https://packages.fhir.org
+  forceReload: false
+  cacheDir: .fhir-ig-cache
+```
+
+## Server and logging
+
+| YAML key | Environment variable | Default |
+| --- | --- | --- |
+| `server.port` | `SERVER_PORT` | `9090` |
+| `server.baseUrl` | `BASE_URL` | `http://localhost:{port}/fhir/r4` |
+| `server.readTimeout` | `SERVER_READ_TIMEOUT` | `30s` |
+| `server.writeTimeout` | `SERVER_WRITE_TIMEOUT` | `60s` |
+| `server.idleTimeout` | `SERVER_IDLE_TIMEOUT` | `120s` |
+| `logging.level` | `LOG_LEVEL` | `info` |
+
+## Database
+
+| YAML key | Environment variable | Default |
+| --- | --- | --- |
+| `database.url` | `DATABASE_URL` | Derived from individual fields |
+| `database.host` | `DB_HOST` | `localhost` |
+| `database.port` | `DB_PORT` | `5432` |
+| `database.user` | `DB_USER` | `fhir` |
+| `database.password` | `DB_PASSWORD` | `fhir` |
+| `database.name` | `DB_NAME` | `fhirdb` |
+| `database.createTables` | `FHIR_CREATE_TABLES` | `false` |
+| `database.planCacheMode` | `DATABASE_PLAN_CACHE_MODE` | `force_custom_plan` |
+
+When `database.url` is set, it overrides the individual database fields.
+
+## Search and write path
+
+| YAML key | Environment variable | Default |
+| --- | --- | --- |
+| `search.probeCap` | `SEARCH_PROBE_CAP` | `5000` |
+| `search.defaultPageSize` | `SEARCH_DEFAULT_PAGE_SIZE` | `20` |
+| `search.maxPageSize` | `SEARCH_MAX_PAGE_SIZE` | `0` |
+| `search.maxChainDepth` | `SEARCH_MAX_CHAIN_DEPTH` | `5` |
+| `write.maxRowsPerStatement` | `WRITE_MAX_ROWS_PER_STATEMENT` | `1000` |
+| `write.maxRowsPerBundle` | `WRITE_MAX_ROWS_PER_BUNDLE` | `100000` |
+
+`search.maxPageSize=0` preserves unlimited legacy behavior. Set an explicit production limit based on client needs.
+
+## Implementation Guides
+
+| YAML key | Environment variable | Default |
+| --- | --- | --- |
+| `ig.packages` | `IG_PACKAGES` | Empty |
+| `ig.registryUrl` | `IG_REGISTRY_URL` | `https://packages.fhir.org` |
+| `ig.forceReload` | `IG_FORCE_RELOAD` | `false` |
+| `ig.cacheDir` | `IG_CACHE_DIR` | `.fhir-ig-cache` |
+
+<Tip>
+  Keep secrets in environment variables or a secret manager. Use YAML for non-secret, reviewable deployment defaults.
+</Tip>
+
+See [Performance tuning](/docs/performance-tuning) before changing search-plan or write-path controls.

--- a/docs/reference/search.mdx
+++ b/docs/reference/search.mdx
@@ -1,0 +1,86 @@
+---
+title: Search
+description: Search FHIR resources using typed parameters, modifiers, chaining, and result controls.
+icon: magnifying-glass
+---
+
+# Search FHIR resources
+
+Search with query parameters on a resource type:
+
+```bash
+curl -sS "http://localhost:9090/fhir/r4/Patient?family=Smith&gender=female" | jq
+```
+
+Parameters are combined with AND semantics. Repeated or comma-separated values follow the behavior defined for the applicable FHIR search parameter.
+
+## Parameter types
+
+| Type | Examples and behavior |
+| --- | --- |
+| String | Case-insensitive prefix by default; supports `:exact` and `:contains` |
+| Token | Code, `system|code`, identifier, and text matching |
+| Date | Partial precision and `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `sa`, `eb`, `ap` prefixes |
+| Number | Precision-aware numeric comparisons |
+| Quantity | Numeric comparisons with system and unit handling, including UCUM canonicalization |
+| URI | Exact values and supported hierarchy modifiers |
+| Reference | Literal references, identifiers, chaining, `_include`, and `_revinclude` |
+| Composite | Combined component values defined by a SearchParameter |
+
+## Common examples
+
+```bash
+# String prefix
+curl -sS "http://localhost:9090/fhir/r4/Patient?name=ali"
+
+# Token with system and code
+curl -sS "http://localhost:9090/fhir/r4/Observation?code=http://loinc.org%7C8867-4"
+
+# Date comparison
+curl -sS "http://localhost:9090/fhir/r4/Observation?date=ge2026-01-01"
+
+# Reference
+curl -sS "http://localhost:9090/fhir/r4/Observation?subject=Patient/123"
+
+# Pagination
+curl -sS "http://localhost:9090/fhir/r4/Patient?_count=50&_page=2"
+```
+
+## Result controls
+
+The server supports result parameters such as:
+
+- `_count` for page size.
+- `_sort` for supported sort fields and directions.
+- `_include` and `_revinclude` for related resources.
+- `_summary` and `_elements` for response shaping.
+- `_total` for total-count behavior where supported.
+
+## Chained search
+
+Traverse a reference and search the target resource:
+
+```bash
+curl -sS "http://localhost:9090/fhir/r4/Observation?subject:Patient.family=Smith"
+```
+
+Chain depth is bounded by `SEARCH_MAX_CHAIN_DEPTH` to protect query complexity.
+
+## POST search
+
+Use form-encoded parameters when the query should not appear in the URL:
+
+```bash
+curl -sS -X POST "http://localhost:9090/fhir/r4/Patient/_search" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "family=Smith" \
+  --data-urlencode "_count=20"
+```
+
+## Custom SearchParameters
+
+Create a FHIR SearchParameter resource, then reindex affected resources so previously stored data receives the new extracted values. New or updated resources are indexed during their write transaction.
+
+<Warning>
+  Adding a SearchParameter definition does not retroactively populate index rows for existing resources. Plan and monitor a reindex operation before exposing the parameter to clients.
+</Warning>


### PR DESCRIPTION
Adds a Mintlify docs site under docs/: navigation config (docs.json) plus 18 pages across get-started, concepts, guides, reference, operations, and development, and Mintlify frontmatter on performance-tuning.md. Verified locally with mint dev.