### PR TITLE
Parse minute-precision date values

### DIFF
--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -360,6 +360,11 @@ func (h *fhirHandler) search(w http.ResponseWriter, r *http.Request) {
 			operationOutcome(w, http.StatusBadRequest, "error", "not-supported", unsup.Msg)
 			return
 		}
+		var invalid *store.InvalidParamError
+		if errors.As(err, &invalid) {
+			operationOutcome(w, http.StatusBadRequest, "error", "invalid", invalid.Msg)
+			return
+		}
 		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
 		return
 	}
@@ -402,6 +407,11 @@ func (h *fhirHandler) searchPost(w http.ResponseWriter, r *http.Request) {
 		var unsup *store.UnsupportedParamError
 		if errors.As(err, &unsup) {
 			operationOutcome(w, http.StatusBadRequest, "error", "not-supported", unsup.Msg)
+			return
+		}
+		var invalid *store.InvalidParamError
+		if errors.As(err, &invalid) {
+			operationOutcome(w, http.StatusBadRequest, "error", "invalid", invalid.Msg)
 			return
 		}
 		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())

--- a/internal/handler/operations.go
+++ b/internal/handler/operations.go
@@ -131,6 +131,11 @@ func (h *fhirHandler) lastN(w http.ResponseWriter, r *http.Request) {
 			operationOutcome(w, http.StatusBadRequest, "error", "not-supported", unsup.Msg)
 			return
 		}
+		var invalid *store.InvalidParamError
+		if errors.As(err, &invalid) {
+			operationOutcome(w, http.StatusBadRequest, "error", "invalid", invalid.Msg)
+			return
+		}
 		operationOutcome(w, http.StatusInternalServerError, "error", "exception", err.Error())
 		return
 	}

--- a/internal/store/helpers_test.go
+++ b/internal/store/helpers_test.go
@@ -316,10 +316,52 @@ func TestExpandDateStringForSearch_RFC3339(t *testing.T) {
 	}
 }
 
+func TestExpandDateStringForSearch_MinutePrecision(t *testing.T) {
+	low, high, err := expandDateStringForSearch("2028-05-15T14:30")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !low.Equal(time.Date(2028, 5, 15, 14, 30, 0, 0, time.UTC)) {
+		t.Fatalf("low = %v", low)
+	}
+	// Minute precision denotes the whole minute
+	if !high.Equal(time.Date(2028, 5, 15, 14, 30, 59, 0, time.UTC)) {
+		t.Fatalf("high = %v", high)
+	}
+}
+
+func TestExpandDateStringForSearch_MinutePrecisionZulu(t *testing.T) {
+	low, high, err := expandDateStringForSearch("2028-01-01T00:00Z")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !low.Equal(time.Date(2028, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("low = %v", low)
+	}
+	if !high.Equal(time.Date(2028, 1, 1, 0, 0, 59, 0, time.UTC)) {
+		t.Fatalf("high = %v", high)
+	}
+}
+
+func TestExpandDateStringForSearch_MinutePrecisionOffset(t *testing.T) {
+	low, high, err := expandDateStringForSearch("2028-05-15T14:30+05:30")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := time.Date(2028, 5, 15, 9, 0, 0, 0, time.UTC)
+	if !low.Equal(want) {
+		t.Fatalf("low = %v, want %v", low, want)
+	}
+	if !high.Equal(want.Add(59 * time.Second)) {
+		t.Fatalf("high = %v", high)
+	}
+}
+
 func TestExpandDateStringForSearch_InvalidDate(t *testing.T) {
-	_, _, err := expandDateStringForSearch("not-a-date")
-	if err == nil {
-		t.Fatal("expected error for invalid date string")
+	for _, s := range []string{"not-a-date", "2028-05-15T14", "2028-05-15T99:99", "2028-05-15Tfoo"} {
+		if _, _, err := expandDateStringForSearch(s); err == nil {
+			t.Fatalf("expected error for invalid date string %q", s)
+		}
 	}
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -60,6 +60,13 @@ type UnsupportedParamError struct{ Msg string }
 
 func (e *UnsupportedParamError) Error() string { return e.Msg }
 
+// InvalidParamError is returned when a search parameter value cannot be parsed
+// (e.g. a malformed date). The HTTP layer should map this to a 400
+// OperationOutcome rather than execute a query built from a garbage value.
+type InvalidParamError struct{ Msg string }
+
+func (e *InvalidParamError) Error() string { return e.Msg }
+
 // newQueryBuilder constructs a query builder carrying the store's configured
 // search tunables, so every search built here honors search.probeCap /
 // search.maxChainDepth (see SearchTuning).
@@ -1576,7 +1583,11 @@ const storedDateRange = "tstzrange(s.value_low, s.value_high, '[]')"
 
 func (b *queryBuilder) buildDateExists(param, value string) string {
 	prefix, dateStr := extractComparatorPrefix(value)
-	low, high := expandDateRange(dateStr)
+	low, high, err := expandDateStringForSearch(dateStr)
+	if err != nil {
+		b.err = &InvalidParamError{Msg: fmt.Sprintf("invalid date value %q for param %q", dateStr, param)}
+		return "FALSE"
+	}
 	rtP := b.next(b.rt)
 	pP := b.next(param)
 
@@ -1905,7 +1916,11 @@ func parseSearchReference(value string) (resourceType, id string) {
 
 func (b *queryBuilder) applyLastUpdated(value string) {
 	prefix, dateStr := extractComparatorPrefix(value)
-	low, high := expandDateRange(dateStr)
+	low, high, err := expandDateStringForSearch(dateStr)
+	if err != nil {
+		b.err = &InvalidParamError{Msg: fmt.Sprintf("invalid date value %q for _lastUpdated", dateStr)}
+		return
+	}
 	switch prefix {
 	case "gt":
 		highP := b.next(high)
@@ -2639,7 +2654,7 @@ func extractComparatorPrefix(s string) (prefix, rest string) {
 func quantizeBand(x float64) float64 { return math.Round(x*1e6) / 1e6 }
 
 // searchBandEnd converts the inclusive, second-truncated band high from
-// expandDateRange into the exclusive end of a half-open search band [low, end):
+// expandDateStringForSearch into the exclusive end of a half-open search band [low, end):
 // the next precision boundary for whole-second highs, so a stored value in the
 // band's final fractional second (e.g. 23:59:59.9 on a day query) stays inside
 // the band; a fractional-second instant advances one microsecond (timestamptz
@@ -2653,11 +2668,6 @@ func searchBandEnd(high time.Time) time.Time {
 		return high.Add(time.Second)
 	}
 	return high.Add(time.Microsecond)
-}
-
-func expandDateRange(s string) (low, high time.Time) {
-	low, high, _ = expandDateStringForSearch(s)
-	return
 }
 
 func expandDateStringForSearch(s string) (low, high time.Time, err error) {
@@ -2684,6 +2694,15 @@ func expandDateStringForSearch(s string) (low, high time.Time, err error) {
 			t, e = time.Parse("2006-01-02T15:04:05", s)
 		}
 		if e != nil {
+			// Minute precision — search values may omit seconds ("minutes
+			// SHALL be present if an hour is present"); the value denotes
+			// the whole minute.
+			for _, layout := range []string{"2006-01-02T15:04Z07:00", "2006-01-02T15:04"} {
+				if t, e = time.Parse(layout, s); e == nil {
+					low, high = t, t.Add(time.Minute-time.Second)
+					return
+				}
+			}
 			return time.Time{}, time.Time{}, e
 		}
 		low, high = t, t

--- a/internal/store/search_dateband_test.go
+++ b/internal/store/search_dateband_test.go
@@ -17,6 +17,7 @@
 package store
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -72,5 +73,55 @@ func TestBuildDateExists_HalfOpenBandOps(t *testing.T) {
 		if got := b.args[2].(time.Time); !got.Equal(tc.bound) {
 			t.Errorf("%s: bound %v, want %v", tc.value, got, tc.bound)
 		}
+	}
+}
+
+// TestBuildDateExists_MinutePrecisionBand pins the minute-precision band
+// (seconds omitted, valid per the FHIR search date format): the value covers
+// its whole minute, so the exclusive band end is the start of the next minute.
+func TestBuildDateExists_MinutePrecisionBand(t *testing.T) {
+	minuteStart := time.Date(2028, 5, 15, 14, 30, 0, 0, time.UTC)
+	nextMinute := time.Date(2028, 5, 15, 14, 31, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		value string
+		frag  string
+		bound time.Time
+	}{
+		{"gt2028-05-15T14:30", "s.value_high >= $3", nextMinute},
+		{"lt2028-05-15T14:30", "s.value_low < $3", minuteStart},
+		{"ge2028-05-15T14:30", "s.value_high >= $3", minuteStart},
+	} {
+		b := &queryBuilder{rt: "Observation"}
+		sql := b.buildDateExists("date", tc.value)
+		if b.err != nil {
+			t.Fatalf("%s: unexpected builder error: %v", tc.value, b.err)
+		}
+		if !strings.Contains(sql, tc.frag) {
+			t.Errorf("%s: missing %q in:\n%s", tc.value, tc.frag, sql)
+		}
+		if got := b.args[2].(time.Time); !got.Equal(tc.bound) {
+			t.Errorf("%s: bound %v, want %v", tc.value, got, tc.bound)
+		}
+	}
+}
+
+// TestBuildDateExists_InvalidDateSetsError pins the failure path: an
+// unparseable date value must surface as an InvalidParamError on the builder
+// (mapped to HTTP 400), never build a predicate from a zero time.
+func TestBuildDateExists_InvalidDateSetsError(t *testing.T) {
+	b := &queryBuilder{rt: "Observation"}
+	b.buildDateExists("date", "gt2028-05-15T99:99")
+	var invalid *InvalidParamError
+	if !errors.As(b.err, &invalid) {
+		t.Fatalf("b.err = %v, want *InvalidParamError", b.err)
+	}
+}
+
+func TestApplyLastUpdated_InvalidDateSetsError(t *testing.T) {
+	b := &queryBuilder{rt: "Observation"}
+	b.applyLastUpdated("gt2028-05-15T99:99")
+	var invalid *InvalidParamError
+	if !errors.As(b.err, &invalid) {
+		t.Fatalf("b.err = %v, want *InvalidParamError", b.err)
 	}
 }


### PR DESCRIPTION
## Problem

FHIR search date values may omit seconds — per the search spec, *"any degree of precision can be provided … the minutes SHALL be present if an hour is present"*, and a timezone is only a SHOULD. The server rejected minute-precision values (e.g. `date=gt2028-05-15T14:30`): `expandDateStringForSearch` knew only the RFC3339 and seconds-without-timezone layouts, and `expandDateRange` discarded the parse error. Date searches then ran with zero `time.Time` bounds (year 0001), so `gt`/`ge`/`sa` matched every resource and `lt`/`le`/`eb` matched none — silently, with HTTP 200.

This accounted for 47 failures in the [HealthSamurai fhir262](https://github.com/HealthSamurai/fhir262) conformance suite (search prefix matrix, every query value with `Thh:mm` precision). HAPI, Aidbox, and fhir-candle all pass these tests.

## Fix

- `expandDateStringForSearch` accepts minute-precision values, with or without timezone (`2006-01-02T15:04`, `2006-01-02T15:04Z07:00`). The value denotes its whole minute (`[T14:30:00, T14:30:59]`), consistent with the year/month/day precision bands and `searchBandEnd`.
- `expandDateRange` (which swallowed errors) is gone. `buildDateExists` and `applyLastUpdated` (`_lastUpdated`) now surface unparseable values as a new `store.InvalidParamError`, mapped by the HTTP layer to a 400 OperationOutcome with issue code `invalid` — alongside the existing `UnsupportedParamError` handling — instead of executing a query built from a garbage value.

## Verification

- New unit tests: minute-precision expansion (naked / Z / offset), invalid values error, builder sets `InvalidParamError` for date params and `_lastUpdated`, comparator band bounds for minute precision.
- `gofmt` clean, `go vet` clean, `go test -race ./...` green, `go test -tags integration ./internal/store/ ./internal/index/` green.
- fhir262 re-run against the rebuilt image: intervals file **1216/1240** (was 1172/1240), full suite **1541/1572** (was 1497/1572) — all 44 newly passing tests are the minute-precision date searches; remaining interval failures are unrelated ge/le/ap boundary-semantics disagreements with the suite.
- Manual: `GET /Observation?date=gt2028-05-15T14:30` → 200; `GET /Observation?date=gt2028-05-15T99:99` and `GET /Patient?_lastUpdated=gt2028-05-15Tfoo` → 400 OperationOutcome.