### PR TITLE
docs: publish Docusaurus site to GitHub Pages

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,40 @@
+name: Publish documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/docs-publish.yml'
+      - 'website/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: website
+      - name: Build documentation
+        run: npm run build
+        working-directory: website
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: website/build

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
   title: 'WSO2 FHIR Server',
   tagline: 'A production-oriented FHIR R4 REST server built in Go and backed by PostgreSQL',
   url: 'https://wso2.github.io',
-  baseUrl: '/',
+  baseUrl: '/fhir-server/',
   organizationName: 'wso2',
   projectName: 'fhir-server',
   onBrokenLinks: 'throw',
@@ -22,8 +22,8 @@ const config: Config = {
         language: ['en'],
         indexBlog: false,
         indexPages: false,
-        // Docs are served from the site root (routeBasePath: '/').
-        docsRouteBasePath: '/',
+        // Docs are served at /fhir-server/docs on GitHub Pages.
+        docsRouteBasePath: '/docs',
         highlightSearchTermsOnTargetPage: true,
         explicitSearchResultPath: true,
         searchBarShortcutHint: false,
@@ -37,7 +37,7 @@ const config: Config = {
       {
         docs: {
           path: 'docs',
-          routeBasePath: '/',
+          routeBasePath: '/docs',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/wso2/fhir-server/edit/main/website/',
         },
@@ -60,7 +60,7 @@ const config: Config = {
         alt: 'WSO2',
         src: 'img/logo.svg',
         srcDark: 'img/logo-dark.svg',
-        href: '/',
+        href: '/docs/',
       },
       items: [
         {


### PR DESCRIPTION
## Purpose

Publish the Docusaurus documentation at https://wso2.github.io/fhir-server/docs.

## Approach

- Build `website/` with its locked Node.js dependencies on pushes to `main` and manual dispatch.
- Deploy `website/build` to the `gh-pages` branch.
- Configure Docusaurus for the `/fhir-server/` project path and `/docs` route.

## Testing

- [x] `cd website && npm ci && npm run build`
- [ ] `make test` (not run; documentation-only change)
- [ ] `make test-integration` (not applicable)
- [ ] `make lint` (not run; documentation-only change)

## Checklist

- [x] No secrets, credentials, or tokens are committed
- [x] Documentation updated where relevant

## Release note

Publish FHIR Server documentation to GitHub Pages.

## Related PRs / issues

N/A