### PR TITLE
docs: align the doc site with the shipped server behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Holds the core FHIR R4 resource StructureDefinitions (one row per resource type)
 | `GET` | `/{type}/{id}/_history/{vid}` | 200, 400, 404 | Read specific version |
 | `POST` | `/{type}` | 201 | Create resource |
 | `PUT` | `/{type}/{id}` | 200, 201, 400, 404, 412, 422 | Update resource (creates at the given id when missing — update-as-create; 404 only with `If-Match`) |
-| `PATCH` | `/{type}/{id}` | 200, 400, 404 | JSON Merge Patch (RFC 7396) |
+| `PATCH` | `/{type}/{id}` | 200, 400, 404 | JSON Merge Patch, JSON Patch, XML Patch, or FHIR Patch — selected by `Content-Type` |
 | `DELETE` | `/{type}/{id}` | 204, 404 | Soft delete |
 | `GET` | `/{type}` | 200 | Search |
 | `POST` | `/{type}/_search` | 200 | Search (form-encoded body) |
@@ -616,7 +616,14 @@ curl -X PATCH http://localhost:9090/fhir/r4/Patient/550e8400-e29b-41d4-a716-4466
   -d '{"active": true}'
 ```
 
-Uses [JSON Merge Patch (RFC 7396)](https://tools.ietf.org/html/rfc7396): set a key to `null` to delete it. PATCH does not enforce `Content-Type` — a wrong type will fail with 400 when the body cannot be parsed as JSON.
+Four patch formats are supported, selected by `Content-Type`:
+
+| `Content-Type` | Format |
+|---|---|
+| `application/merge-patch+json` (or absent) | [JSON Merge Patch (RFC 7396)](https://tools.ietf.org/html/rfc7396) — set a key to `null` to delete it |
+| `application/json-patch+json` | [JSON Patch (RFC 6902)](https://tools.ietf.org/html/rfc6902) |
+| `application/xml-patch+xml` | XML Patch |
+| `application/fhir+json` (body is `Parameters`) | FHIR Patch |
 
 #### Delete a Resource
 
@@ -666,7 +673,7 @@ The response is a `transaction-response` Bundle whose entries carry
 | `transaction` | All entries commit in a **single DB transaction** | Whole Bundle rolls back; a single `OperationOutcome` is returned with the failing entry's status |
 | `batch` | Each entry runs **independently** | Only that entry fails (its `response` carries an `OperationOutcome`); siblings are unaffected; overall status is `200` |
 
-Supported per-entry methods: `POST`, `PUT`, `PATCH` (JSON Merge Patch), `DELETE`, `GET`.
+Supported per-entry methods: `POST`, `PUT`, `PATCH`, `DELETE`, `GET`.
 
 - **Reference resolution** — within a `transaction`, `urn:uuid:` (and absolute-URL)
   references between entries are rewritten to the server-assigned `Type/id` before
@@ -964,14 +971,14 @@ fails startup, naming the offending variable. See the
 | `token` | `gender=female`, `code=http://loinc.org\|8310-5` | `:missing`, `:in`, `:not-in`, `:below`, `:above` | `system\|code`, `\|code` (any system), `system\|` (any code with that system). The `:in`/`:not-in`/`:below`/`:above` modifiers require an external terminology server — see [Terminology](#11-terminology). |
 | `date` | `birthdate=ge1980`, `date=2024-01-15` | `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `sa`, `eb`, `ap` | `eq` follows R4 containment semantics (the search range must fully contain the stored range); `ne` matches when the search range does not fully contain the stored range; `ap` matches on range overlap; `sa` matches values that start after the search range and `eb` matches values that end before it. Matching is per indexed value, so a resource with multiple values for one param can match both `eq` and `ne` |
 | `number` | `probability=gt0.8` | `eq`, `lt`, `gt` | |
-| `reference` | `subject=Patient/abc123` | — | |
+| `reference` | `subject=Patient/abc123` | `:missing`, `:identifier`, `:{Type}` | Chained parameters (`subject.name=smith`) and `_has` are also supported |
+| `quantity` | `value-quantity=gt5.4` | comparator prefixes (`eq`, `lt`, `gt`, …), `:missing` | Compared on the canonicalized value and units |
+| `uri` | `url=http://example.com/vs` | `:below`, `:above`, `:missing` | `:below` matches by path prefix |
 
-**Not yet queryable** — these types are indexed (rows written to their `sp_*` tables) but the query builder does not read from them:
+**Not yet queryable** — this type is indexed (rows written to its `sp_*` table) but the query builder does not read from it:
 
 | Type | Table | Status |
 |---|---|---|
-| `quantity` | `sp_quantity` | Indexed only |
-| `uri` | `sp_uri` | Indexed only |
 | `special` (Location.near) | `sp_coords` | Indexed only |
 
 Special parameters handled without `sp_*` tables:
@@ -983,7 +990,7 @@ Special parameters handled without `sp_*` tables:
 | `_text` / `_content` | Queries `resources.search_text` tsvector — **not currently functional** (column is never populated) |
 | `_include` | Fetches all forward references for matched resources |
 | `_revinclude` | Fetches all reverse references for matched resources |
-| `_sort` | **Silently ignored** — results always ordered by `last_updated DESC` |
+| `_sort` | Comma-separated sort keys, leading `-` for descending (e.g. `_sort=-_lastUpdated`); when absent, results are ordered by `last_updated DESC` |
 | `_count`, `_page` | Pagination |
 
 ### Registering a custom SearchParameter
@@ -1002,7 +1009,9 @@ curl -X POST http://localhost:9090/fhir/r4/SearchParameter \
   }'
 ```
 
-The parameter is available for searching immediately and persists across restarts.
+The parameter persists across restarts and starts indexing **new writes** immediately. Existing
+resources are not backfilled (there is no `$reindex` operation yet), so resources written before
+the parameter was registered must be re-written (`PUT`) to become findable through it.
 
 ---
 

--- a/website/docs/administration/configuration.md
+++ b/website/docs/administration/configuration.md
@@ -72,7 +72,12 @@ ig:
 | `server.readTimeout` | `SERVER_READ_TIMEOUT` | `30s` |
 | `server.writeTimeout` | `SERVER_WRITE_TIMEOUT` | `60s` |
 | `server.idleTimeout` | `SERVER_IDLE_TIMEOUT` | `120s` |
+| `server.maxRequestBodyBytes` | `SERVER_MAX_REQUEST_BODY_BYTES` | `209715200` (200 MiB) |
 | `logging.level` | `LOG_LEVEL` | `info` |
+
+A request whose body exceeds `server.maxRequestBodyBytes` is rejected with
+`413 Request Entity Too Large` before being read into memory. Valid range: 1 MiB to 2 GiB.
+Raise it for deployments that accept very large transaction Bundles.
 
 ## Database
 
@@ -88,6 +93,15 @@ ig:
 | `database.planCacheMode` | `DATABASE_PLAN_CACHE_MODE` | `force_custom_plan` |
 
 When `database.url` is set, it overrides the individual database fields.
+
+:::warning
+`database.planCacheMode` is load-bearing. `force_custom_plan` makes PostgreSQL re-plan every
+search with its actual parameter values, which is what keeps skewed parameters (a common code
+versus a rare one) from being served by a single cached generic plan. Setting it to `auto` or
+`force_generic_plan` re-exposes exactly the misestimate pathology the search architecture is
+designed to avoid — change it only for controlled experiments. See
+[Performance tuning](https://github.com/wso2/fhir-server/blob/main/docs/performance-tuning.md).
+:::
 
 ## Search and write path
 
@@ -113,12 +127,21 @@ When `database.url` is set, it overrides the individual database fields.
 
 ## Validation and terminology
 
-These controls are environment-variable only; they have no YAML key:
+Validation toggles live in the `validation:` YAML block and can be overridden per setting by
+environment variable. The `FHIR_VALIDATION_*` names are canonical; the legacy names shown in
+parentheses are still honored as fallbacks. An unparseable boolean value fails startup.
+
+| YAML key | Environment variable | Default | Effect |
+| --- | --- | --- | --- |
+| `validation.base` | `FHIR_VALIDATION_BASE` (legacy `FHIR_BASE_VALIDATION`) | `true` | Base R4 structural validation on writes; set `false` to disable. |
+| `validation.profile` | `FHIR_VALIDATION_PROFILE` (legacy `FHIR_VALIDATE_ON_WRITE`) | `false` | Set `true` to enforce declared profiles on create and update. |
+| `validation.referentialIntegrityOnWrite` | `FHIR_VALIDATION_REFERENTIAL_INTEGRITY_ON_WRITE` | `true` | Rejects writes whose local literal references do not resolve (`422`) — see [Validation](../conformance/validation.md#referential-integrity). |
+| `validation.referentialIntegrityOnDelete` | `FHIR_VALIDATION_REFERENTIAL_INTEGRITY_ON_DELETE` | `true` | Rejects deletes of resources still referenced by others (`409`) — see [Validation](../conformance/validation.md#referential-integrity). |
+
+Terminology is environment-variable only; it has no YAML key:
 
 | Environment variable | Default | Effect |
 | --- | --- | --- |
-| `FHIR_BASE_VALIDATION` | `true` | Base R4 structural validation on writes; set `false` to disable. |
-| `FHIR_VALIDATE_ON_WRITE` | `false` | Set `true` to enforce declared profiles on create and update. |
 | `FHIR_TERMINOLOGY_URL` | Empty (disabled) | Base URL of the external FHIR terminology server used by terminology-backed search modifiers. |
 
 :::tip

--- a/website/docs/administration/deployment.md
+++ b/website/docs/administration/deployment.md
@@ -53,10 +53,19 @@ The FHIR server handles FHIR resources and tenant-scoped storage. Deploy an API 
 
 ## Timeouts
 
-`SERVER_WRITE_TIMEOUT` bounds the entire handler execution from the HTTP server's perspective. Large transaction Bundles can exceed the default. Measure the largest supported request under expected concurrency, then coordinate the server, proxy, client, and database timeout budgets.
+`SERVER_WRITE_TIMEOUT` is a deadline on the HTTP connection, not on the work: when it expires,
+Go closes the connection but does **not** cancel the handler or its request context — the
+handler runs to completion, so a transaction Bundle may still commit after the client has seen a
+bare `EOF` (not a `504`). Large transaction Bundles can exceed the default. Measure the largest
+supported request under expected concurrency, then coordinate the server, proxy, client, and
+database timeout budgets — and keep the server timeout above the client's, so the client governs
+abandonment.
 
 :::warning
-A client-side EOF during a long transaction Bundle can represent an indeterminate outcome. Reconcile resource state before retrying.
+A client-side `EOF` during a long transaction Bundle is an **indeterminate** outcome: the
+database result is independent of the HTTP result, so the transaction may have committed after
+the connection closed. Reconcile resource state before retrying — an unconditional retry may
+apply the bundle twice.
 :::
 
 ## After bulk loading

--- a/website/docs/administration/multi-tenancy.md
+++ b/website/docs/administration/multi-tenancy.md
@@ -29,6 +29,22 @@ Run one service and database while scoping data with a tenant identifier and Pos
 
 No configuration flag is needed: the server always mounts both the bare FHIR base path and the tenant-prefixed routes, and the row-level security policies are part of the standard schema. Requests to the bare path use the default tenant scope; requests under a tenant prefix are scoped to that tenant.
 
+:::danger The database role must NOT be a superuser
+PostgreSQL superusers — and any role with `BYPASSRLS` — ignore Row-Level Security, which
+silently disables tenant isolation. Create a dedicated least-privilege role for the server and
+connect as it:
+
+```sql
+CREATE ROLE fhir_app LOGIN PASSWORD '…';            -- NOT a superuser
+GRANT USAGE ON SCHEMA public TO fhir_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO fhir_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO fhir_app;
+```
+
+Run migrations as the owner/admin role; run the server as `fhir_app`. Single-tenant deployments
+that never use the tenant routes are unaffected either way.
+:::
+
 Tenant-aware routes use:
 
 ```text

--- a/website/docs/api/capability-statement.md
+++ b/website/docs/api/capability-statement.md
@@ -60,8 +60,8 @@ Each entry reports:
 | `readHistory` | `true` — past versions are readable via [history and vread](./interactions.md) |
 | `conditionalCreate` / `conditionalUpdate` | `true` — see [Conditional operations](./conditional.md) |
 | `conditionalDelete` | `single` — a conditional delete may match at most one resource |
-| `updateCreate` | `false` — `PUT` to an unknown id does not create the resource |
-| `referencePolicy` | `literal`, `logical` — both `Type/id` and identifier-based references are indexed |
+| `updateCreate` | `true` — `PUT` to an unknown id creates the resource (update-as-create) |
+| `referencePolicy` | `literal`, `logical` — both `Type/id` and identifier-based references are indexed — plus `enforced` while referential-integrity checking on write is enabled (the default) |
 | `searchParam` | every parameter available for the type, base plus IG plus custom |
 | `searchInclude` | reference parameters usable as `_include` targets |
 | `searchRevInclude` | parameters usable as `_revinclude` targets |
@@ -78,10 +78,10 @@ curl -sS http://localhost:9090/fhir/r4/metadata \
   "conditionalCreate": true,
   "conditionalUpdate": true,
   "conditionalDelete": "single",
-  "updateCreate": false,
+  "updateCreate": true,
   "versioning": "versioned",
   "readHistory": true,
-  "referencePolicy": ["literal", "logical"]
+  "referencePolicy": ["literal", "logical", "enforced"]
 }
 ```
 

--- a/website/docs/api/interactions.md
+++ b/website/docs/api/interactions.md
@@ -191,8 +191,10 @@ Notes:
 - `If-Match` is optional but recommended — see
   [optimistic locking](./conditional.md#optimistic-locking-with-if-match).
 - A body `id` that disagrees with the URL is rejected with `400 Bad Request`.
-- `PUT` to an id that does not exist returns `404 Not Found`. The server does **not** do
-  update-as-create, and advertises `updateCreate: false`.
+- `PUT` to an id that does not exist **creates** the resource at that id and returns
+  `201 Created` (update-as-create). The server advertises `updateCreate: true`. The one
+  exception: when the request carries an `If-Match` header, a missing resource returns
+  `404 Not Found` instead of being created.
 - `PUT` to a *deleted* id restores the resource at a new version.
 
 ## Patch

--- a/website/docs/api/operations.md
+++ b/website/docs/api/operations.md
@@ -106,14 +106,17 @@ curl -sS -X POST 'http://localhost:9090/fhir/r4/Patient/$validate?profile=http:/
 
 Behaviour worth knowing:
 
-- The body must be the **resource itself**. A `Parameters` wrapper is not unwrapped: at type level it
-  is rejected as a type mismatch, and at system level the `Parameters` resource is what gets
-  validated. The `mode` parameter (`create`/`update`/`delete`) is not implemented.
+- The body may be the **resource itself** or a `Parameters` envelope whose parameter named
+  `resource` carries it — the envelope is unwrapped at every scope. An envelope without a
+  `resource` parameter is rejected with `400 Bad Request`, except `mode=delete`, which returns
+  a valid outcome without checking anything (deletes carry no resource to validate). Other
+  `mode` values do not change what is validated.
 - Only the first `?profile=` value is read.
 - Profile resolution is **soft-fail**: a profile that is not loaded is skipped silently, so an
   unrecognised `?profile=` returns `200 OK` rather than an error. Confirm packages loaded with
   [`/metadata`](./capability-statement.md).
-- Base R4 validation is included unless `FHIR_BASE_VALIDATION=false`. FHIRPath `invariant` failures
+- Base R4 validation is included unless `FHIR_VALIDATION_BASE=false` (the legacy name
+  `FHIR_BASE_VALIDATION` is still honored). FHIRPath `invariant` failures
   are reported as warnings — see [Validation](../conformance/validation.md).
 
 ## $everything

--- a/website/docs/conformance/resource-types.md
+++ b/website/docs/conformance/resource-types.md
@@ -20,7 +20,7 @@ curl -X POST http://localhost:9090/fhir/r4/Observation \
   -d '{"resourceType": "Observation", "status": "final", "code": {"text": "Heart rate"}}'
 ```
 
-There is no per-type enablement step. Using a type for the first time requires no migration or configuration. By default, each incoming resource is validated against the base R4 StructureDefinition for its type, which the server ships and loads at startup (`FHIR_BASE_VALIDATION=false` disables this).
+There is no per-type enablement step. Using a type for the first time requires no migration or configuration. By default, each incoming resource is validated against the base R4 StructureDefinition for its type, which the server ships and loads at startup (`FHIR_VALIDATION_BASE=false` disables this).
 
 :::tip
 The authoritative list for a running server is its CapabilityStatement: `GET /metadata`. Clients should prefer it over documentation, since deployments may add Implementation Guides and custom SearchParameters.

--- a/website/docs/conformance/validation.md
+++ b/website/docs/conformance/validation.md
@@ -48,16 +48,58 @@ The response is an OperationOutcome:
 
 Base resource checks protect fundamental structure. Profile validation is deployment-controlled and applies to profiles declared in `meta.profile` when their StructureDefinitions are available.
 
-Two environment variables control the behavior:
+The toggles live in the `validation:` YAML block, and each can be overridden by an environment
+variable (the legacy names in parentheses remain accepted as fallbacks):
 
-| Variable | Default | Effect |
-| --- | --- | --- |
-| `FHIR_BASE_VALIDATION` | `true` | Validates every write against the base R4 StructureDefinition. Set `false` to disable. |
-| `FHIR_VALIDATE_ON_WRITE` | `false` | Set `true` to additionally enforce declared profiles on create and update. |
+| YAML key | Environment variable | Default | Effect |
+| --- | --- | --- | --- |
+| `validation.base` | `FHIR_VALIDATION_BASE` (legacy `FHIR_BASE_VALIDATION`) | `true` | Validates every write against the base R4 StructureDefinition. Set `false` to disable. |
+| `validation.profile` | `FHIR_VALIDATION_PROFILE` (legacy `FHIR_VALIDATE_ON_WRITE`) | `false` | Set `true` to additionally enforce declared profiles on create and update. |
+| `validation.referentialIntegrityOnWrite` | `FHIR_VALIDATION_REFERENTIAL_INTEGRITY_ON_WRITE` | `true` | Rejects writes whose local literal references do not resolve — see below. |
+| `validation.referentialIntegrityOnDelete` | `FHIR_VALIDATION_REFERENTIAL_INTEGRITY_ON_DELETE` | `true` | Rejects deletes of resources that are still referenced — see below. |
 
 :::note
-The default behavior favors FHIR interoperability. Load the required Implementation Guides and set `FHIR_VALIDATE_ON_WRITE=true` when a deployment requires profile enforcement.
+The default behavior favors FHIR interoperability. Load the required Implementation Guides and set `FHIR_VALIDATION_PROFILE=true` when a deployment requires profile enforcement.
 :::
+
+Independent of these toggles, writes always enforce a small set of required fields whose absence
+breaks core workflows — for example `Observation.code`, `Encounter.status` and `Encounter.class`,
+`Condition.subject`, `DiagnosticReport.status` and `DiagnosticReport.code`, and
+`AllergyIntolerance.patient`. A present-but-empty value (`null`, `""`, `{}`, `[]`) counts as
+missing and is rejected with `422 Unprocessable Entity`.
+
+## Referential integrity
+
+At the end of every write transaction — after all entries are flushed, inside the same
+transaction — the store verifies that the resulting database state is referentially consistent:
+
+- **On write** (`validation.referentialIntegrityOnWrite`, default `true`): every local literal
+  reference (`Type/id`) carried by a created, updated, or patched resource must resolve to a
+  live (non-deleted) resource. A violation aborts the transaction with
+  `422 Unprocessable Entity`.
+- **On delete** (`validation.referentialIntegrityOnDelete`, default `true`): a resource cannot
+  be deleted while live resources still reference it through an indexed reference search
+  parameter. A violation aborts the transaction with `409 Conflict`.
+
+Because the checks run after the flush, transaction Bundles are order-independent: a Bundle that
+creates both an Observation and the Patient it points at passes regardless of entry order, and a
+violation rolls the whole Bundle back.
+
+Scope and exemptions:
+
+- Only local literal references are existence-checked. Absolute URLs, `urn:` values, internal
+  fragments (`#contained`), conditional references (`Type?query`), and logical
+  (identifier-only) references are never checked.
+- The delete-side check consults the reference search index (`sp_reference`), so it sees exactly
+  the references indexed by a reference-type SearchParameter.
+- `Bundle`-typed resources (stored documents or collections) are exempt from the write-side
+  check: their entry-local references resolve against the bundle itself, not this server.
+
+`$validate` does not check referential integrity, so a resource can validate clean and still be
+rejected on write. When both checks are enabled, the CapabilityStatement advertises
+`referencePolicy: ["literal", "logical", "enforced"]`. Bulk loads whose data arrives out of
+order (for example Synthea exports imported file by file) may need
+`FHIR_VALIDATION_REFERENTIAL_INTEGRITY_ON_WRITE=false` for the duration of the import.
 
 ## Profile availability
 


### PR DESCRIPTION
## Why

A review of the published doc site (https://wso2.github.io/fhir-server/docs/) against the repository README and the code found several places where the site contradicts what the server actually does, plus a few undocumented settings. This PR fixes the site content and also refreshes README claims that had gone stale relative to the shipped code.

Every behavioral claim below was verified against the code before editing.

## Doc-site fixes

- **update-as-create** (`api/interactions.md`, `api/capability-statement.md`): the site said `PUT` to a missing id returns `404` and `updateCreate: false`. The server creates the resource and advertises `updateCreate: true` (`internal/handler/handlers.go` — `UpdateOrCreate`, capability emission); `404` happens only when the request carries `If-Match`.
- **`$validate` Parameters envelope** (`api/operations.md`): the site said a `Parameters` wrapper is not unwrapped. It is, at every scope (`runValidate` / `unwrapValidateParams`); `mode=delete` returns a valid outcome, and an envelope without a `resource` parameter gets `400`.
- **`referencePolicy`** (`api/capability-statement.md`): includes `"enforced"` while referential-integrity-on-write is enabled, which is the default.
- **Validation configuration** (`administration/configuration.md`, `conformance/validation.md`, plus legacy env names in `api/operations.md` and `conformance/resource-types.md`): the site claimed the validation toggles are environment-variable only and listed only the legacy names. They live in the `validation:` YAML block with canonical `FHIR_VALIDATION_*` env vars (legacy names still honored as fallbacks — `internal/config/config.go`, `config.example.yaml`). The two referential-integrity toggles were entirely undocumented.
- **Referential integrity** (`conformance/validation.md`): previously had zero coverage on the site. Documented: `422` on unresolvable local literal references at write, `409` on delete-while-referenced, the post-flush in-transaction check that makes Bundles order-independent, the exemptions (absolute URLs, `urn:`, `#contained`, conditional and logical references, `Bundle`-typed resources), and the bulk-load escape hatch. Also documented the always-on required-field checks.
- **`server.maxRequestBodyBytes`** (`administration/configuration.md`): added the setting, its `SERVER_MAX_REQUEST_BODY_BYTES` env var, the 200 MiB default, the 1 MiB–2 GiB range, and the `413` rejection — previously absent from the site.
- **`SERVER_WRITE_TIMEOUT`** (`administration/deployment.md`): the site said it "bounds the entire handler execution". It is a connection deadline: Go closes the connection but does not cancel the handler, so a transaction Bundle can still commit after the client sees a bare `EOF`. Reworded, and strengthened the indeterminate-outcome warning (an unconditional retry may apply a bundle twice).
- **Multi-tenancy** (`administration/multi-tenancy.md`): added the warning that superusers and `BYPASSRLS` roles bypass row-level security — silently disabling tenant isolation — with the least-privilege role recipe from the README.
- **Plan cache mode** (`administration/configuration.md`): added a warning that `force_custom_plan` is load-bearing and should only be changed for controlled experiments.

## README fixes (stale relative to the shipped code)

- `_sort` is implemented (`internal/store/search.go`), not "silently ignored".
- `quantity` and `uri` parameters are queryable (`buildQuantityExists` / `buildURIExists`), not "indexed only"; only `special` (`Location.near`) remains index-only.
- `PATCH` supports four formats selected by `Content-Type` (merge-patch, JSON Patch, XML Patch, FHIR Patch), not only JSON Merge Patch.
- `reference` parameters support `:missing` / `:identifier` / `:{Type}`, chaining, and `_has`.
- A custom `SearchParameter` indexes new writes only; existing resources are not backfilled (no `$reindex` yet).

## Verification

- `npm run build` in `website/` succeeds (Docusaurus also checks internal links).
- No Go changes.

## Out of scope / follow-ups

- `docs/performance-tuning.md` is linked from the site but not published on it; whether to publish it (or a summary) on the site is a separate decision.
- README "Extending the Server" how-tos have no site equivalent.